### PR TITLE
feat: Add inverse support

### DIFF
--- a/host-go/config/config.go
+++ b/host-go/config/config.go
@@ -20,7 +20,13 @@ func Load[TSource any, TResult any](path string, src enumerable.Enumerable[TSour
 
 	modules := []module.Module{}
 	for _, lensModule := range lensConfig.Lenses {
-		module, err := engine.LoadModule(lensModule.Path, lensModule.Arguments)
+		var module module.Module
+		var err error
+		if lensModule.Inverse {
+			module, err = engine.LoadInverse(lensModule.Path, lensModule.Arguments)
+		} else {
+			module, err = engine.LoadModule(lensModule.Path, lensModule.Arguments)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/host-go/config/internal/json/json.go
+++ b/host-go/config/internal/json/json.go
@@ -13,6 +13,7 @@ type Lens struct {
 
 type LensModule struct {
 	Path      string         `json:"path"`
+	Inverse   bool           `json:"inverse"`
 	Arguments map[string]any `json:"arguments"`
 }
 
@@ -32,6 +33,7 @@ func Load(path string) (model.Lens, error) {
 	for i, lensModule := range lensFile.Lenses {
 		lenses[i] = model.LensModule{
 			Path:      lensModule.Path,
+			Inverse:   lensModule.Inverse,
 			Arguments: lensModule.Arguments,
 		}
 	}

--- a/host-go/config/internal/model/lens.go
+++ b/host-go/config/internal/model/lens.go
@@ -14,6 +14,11 @@ type LensModule struct {
 	// The path to the wasm binary containing the lens transform that you wish to be applied.
 	Path string
 
+	// If true, the module will be inversed.
+	//
+	// This may result in an error if the module does not provide an inverse function.
+	Inverse bool
+
 	// Any additional parameters that you wish to be passed to the lens transform.
 	//
 	// The lens module must expose a `set_param` function if values are provided here.

--- a/host-go/engine/engine.go
+++ b/host-go/engine/engine.go
@@ -44,6 +44,15 @@ func append[TSource any, TResult any](src enumerable.Enumerable[TSource], module
 
 // LoadModule loads a lens at the given path.
 func LoadModule(path string, paramSets ...map[string]any) (module.Module, error) {
+	return loadModule(path, "transform", paramSets...)
+}
+
+// LoadInverse loads the inverse of a lens at the given path.
+func LoadInverse(path string, paramSets ...map[string]any) (module.Module, error) {
+	return loadModule(path, "inverse", paramSets...)
+}
+
+func loadModule(path string, functionName string, paramSets ...map[string]any) (module.Module, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return module.Module{}, err
@@ -73,7 +82,7 @@ func LoadModule(path string, paramSets ...map[string]any) (module.Module, error)
 		return module.Module{}, err
 	}
 
-	transform, err := instance.Exports.GetRawFunction("transform")
+	transform, err := instance.Exports.GetRawFunction(functionName)
 	if err != nil {
 		return module.Module{}, err
 	}

--- a/tests/integration/cli/with_inverse_modules_test.go
+++ b/tests/integration/cli/with_inverse_modules_test.go
@@ -1,0 +1,64 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/tests/modules"
+)
+
+func TestInverseWithModules(t *testing.T) {
+	type Value struct {
+		FullName string
+		Age      int
+	}
+
+	executeTest(
+		t,
+		TestCase[Value, Value]{
+			LensFile: `
+			{
+				"lenses": [
+					{
+						"path": "` + modules.WasmPath2 + `"
+					},
+					{
+						"path": "` + modules.WasmPath2 + `",
+						"inverse": true
+					},
+					{
+						"path": "` + modules.WasmPath2 + `",
+						"inverse": true
+					}
+				]
+			}`,
+			Input: []Value{
+				{
+					FullName: "John",
+					Age:      3,
+				},
+				{
+					FullName: "Fred",
+					Age:      5,
+				},
+				{
+					FullName: "Orpheus",
+					Age:      7,
+				},
+			},
+			ExpectedOutput: []Value{
+				{
+					FullName: "John",
+					Age:      2,
+				},
+				{
+					FullName: "Fred",
+					Age:      4,
+				},
+				{
+					FullName: "Orpheus",
+					Age:      6,
+				},
+			},
+		},
+	)
+}

--- a/tests/integration/cli/with_inverse_test.go
+++ b/tests/integration/cli/with_inverse_test.go
@@ -1,0 +1,81 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/tests/modules"
+)
+
+func TestInverse(t *testing.T) {
+	type Value struct {
+		FullName string
+		Age      int
+	}
+
+	executeTest(
+		t,
+		TestCase[Value, Value]{
+			LensFile: `
+			{
+				"lenses": [
+					{
+						"path": "` + modules.WasmPath2 + `",
+						"inverse": true
+					}
+				]
+			}`,
+			Input: []Value{
+				{
+					FullName: "John",
+					Age:      3,
+				},
+				{
+					FullName: "Fred",
+					Age:      5,
+				},
+				{
+					FullName: "Orpheus",
+					Age:      7,
+				},
+			},
+			ExpectedOutput: []Value{
+				{
+					FullName: "John",
+					Age:      2,
+				},
+				{
+					FullName: "Fred",
+					Age:      4,
+				},
+				{
+					FullName: "Orpheus",
+					Age:      6,
+				},
+			},
+		},
+	)
+}
+
+func TestInverseErrorsGivenNoInverseAvailable(t *testing.T) {
+	type Value struct {
+		Name string
+		Age  int
+	}
+
+	executeTest(
+		t,
+		TestCase[Value, Value]{
+			LensFile: `
+			{
+				"lenses": [
+					{
+						"path": "` + modules.WasmPath1 + `",
+						"inverse": true
+					}
+				]
+			}`,
+			Input:         []Value{},
+			ExpectedError: "Export `inverse` does not exist",
+		},
+	)
+}

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -6,7 +6,7 @@ pub struct Value {
     #[serde(rename = "FullName")]
     pub name: String,
     #[serde(rename = "Age")]
-	pub age: u64,
+	pub age: i64,
 }
 
 #[no_mangle]
@@ -38,6 +38,34 @@ fn try_transform(ptr: *mut u8) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
         age: input.age + 1,
     };
     
+    let result_json = serde_json::to_vec(&result)?;
+    Ok(Some(result_json))
+}
+
+#[no_mangle]
+pub extern fn inverse(ptr: *mut u8) -> *mut u8 {
+    match try_inverse(ptr) {
+        Ok(o) => match o {
+            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
+            None => lens_sdk::nil_ptr(),
+        },
+        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
+    }
+}
+
+fn try_inverse(ptr: *mut u8) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
+    let input = match lens_sdk::try_from_mem::<Value>(ptr)? {
+        Some(v) => v,
+        // Implementations of `transform` are free to handle nil however they like. In this
+        // implementation we chose to return nil given a nil input.
+        None => return Ok(None),
+    };
+
+    let result = Value {
+        name: input.name,
+        age: input.age - 1,
+    };
+
     let result_json = serde_json::to_vec(&result)?;
     Ok(Some(result_json))
 }

--- a/tests/modules/utils.go
+++ b/tests/modules/utils.go
@@ -11,6 +11,8 @@ var WasmPath1 string = getPathRelativeToProjectRoot(
 )
 
 // WasmPath2 contains a simple wasm32 rust lens that takes an item of `type2` and adds 1 to its age.
+//
+// Module also supplies an inverse function.
 var WasmPath2 string = getPathRelativeToProjectRoot(
 	"tests/modules/rust_wasm32_simple2/target/wasm32-unknown-unknown/debug/rust_wasm32_simple2.wasm",
 )


### PR DESCRIPTION
Resolves https://github.com/lens-vm/lens/issues/23

Adds the ability to request the inverse of a transform, should the module support it.

It is configurable on a lens by lens basis, a top-level param may be added in https://github.com/lens-vm/lens/issues/28

~~Branch is based off of https://github.com/lens-vm/lens/pull/24, please review the last commit only (`Add inverse support`).~~