### PR TITLE
feat: Make wasm modules enumerable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,15 @@ tests/modules/as_wasm32_simple/package-lock.json
 tests/modules/rust_wasm32_rename/Cargo.lock
 tests/modules/rust_wasm32_rename/target
 tests/modules/rust_wasm32_rename/pkg
+tests/modules/rust_wasm32_counter/Cargo.lock
+tests/modules/rust_wasm32_counter/target
+tests/modules/rust_wasm32_counter/pkg
+tests/modules/rust_wasm32_filter/Cargo.lock
+tests/modules/rust_wasm32_filter/target
+tests/modules/rust_wasm32_filter/pkg
+tests/modules/rust_wasm32_normalize/Cargo.lock
+tests/modules/rust_wasm32_normalize/target
+tests/modules/rust_wasm32_normalize/pkg
 sdk-rust/target
 sdk-rust/Cargo.lock
 host-go/build/host-go.exe

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ tests/modules/rust_wasm32_rename/target
 tests/modules/rust_wasm32_rename/pkg
 sdk-rust/target
 sdk-rust/Cargo.lock
-host-go/build/host-go
+host-go/build/host-go.exe

--- a/host-go/engine/module/instance.go
+++ b/host-go/engine/module/instance.go
@@ -23,7 +23,7 @@ type Instance struct {
 
 	// OwnedBy hosts a reference to any object(s) that may be required to live in memory for the lifetime of this Module.
 	//
-	// This is very important when working with some libraries (such as wasmer-go), as without this dependencies of other members
+	// This is very important when working with some libraries (such as wasmer-go), as without this, dependencies of other members
 	// of this Module may be garbage collected prematurely.
 	OwnedBy any
 }

--- a/host-go/engine/module/instance.go
+++ b/host-go/engine/module/instance.go
@@ -16,7 +16,7 @@ type Instance struct {
 	Transform func(next func() MemSize) (MemSize, error)
 
 	// GetData returns the current state of the linear memory that this module uses.
-
+	//
 	// Values written to the return slice will be made available to this module, however changes made by the
 	// module after this function has been called are not guaranteed to be visible to the previously returned slice.
 	GetData func() []byte

--- a/host-go/engine/module/instance.go
+++ b/host-go/engine/module/instance.go
@@ -11,17 +11,19 @@ type Instance struct {
 	Alloc func(size MemSize) (MemSize, error)
 
 	// Transform transforms the data stored at the given start index, returning the start index of the result.
-	Transform func(startIndex MemSize) (MemSize, error)
-
-	// GetData returns the current state of the linear memory that this instance uses.
 	//
-	// Values written to the return slice will be made available to this instance, however changes made by the
-	// instance after this function has been called are not guaranteed to be visible to the previously returned slice.
+	// The next function provided should return a wasm memory pointer to the next source item to be transformed.
+	Transform func(next func() MemSize) (MemSize, error)
+
+	// GetData returns the current state of the linear memory that this module uses.
+
+	// Values written to the return slice will be made available to this module, however changes made by the
+	// module after this function has been called are not guaranteed to be visible to the previously returned slice.
 	GetData func() []byte
 
-	// ownedBy hosts a reference to any object(s) that may be required to live in memory for the lifetime of this Instance.
+	// ownedBy hosts a reference to any object(s) that may be required to live in memory for the lifetime of this Module.
 	//
 	// This is very important when working with some libraries (such as wasmer-go), as without this dependencies of other members
-	// of this Instance may be garbage collected prematurely.
+	// of this Module may be garbage collected prematurely.
 	OwnedBy any
 }

--- a/host-go/engine/module/instance.go
+++ b/host-go/engine/module/instance.go
@@ -21,7 +21,7 @@ type Instance struct {
 	// module after this function has been called are not guaranteed to be visible to the previously returned slice.
 	GetData func() []byte
 
-	// ownedBy hosts a reference to any object(s) that may be required to live in memory for the lifetime of this Module.
+	// OwnedBy hosts a reference to any object(s) that may be required to live in memory for the lifetime of this Module.
 	//
 	// This is very important when working with some libraries (such as wasmer-go), as without this dependencies of other members
 	// of this Module may be garbage collected prematurely.

--- a/host-go/engine/module/protocol.go
+++ b/host-go/engine/module/protocol.go
@@ -6,6 +6,7 @@ package module
 
 import (
 	"encoding/binary"
+	"math"
 )
 
 // LenType is the type used to represent the byte length of an item transmitted to/from a lens module.
@@ -39,13 +40,27 @@ var LenByteOrder = binary.LittleEndian
 type MemSize = int32
 
 const (
+	ErrTypeID  TypeIdType = -1
 	NilTypeID  TypeIdType = 0
 	JSONTypeID TypeIdType = 1
+
+	// A type id that denotes the end of stream.
+	//
+	// If recieved it signals that the end of the stream has been reached and that the source will no longer yield
+	// new values.
+	EOSTypeID TypeIdType = math.MaxInt8
 )
 
 // IsError returns true if the given typeId is an error type.
 //
 // Otherwise returns false.
-func IsError(typeId TypeIdType) bool {
+func (typeId TypeIdType) IsError() bool {
 	return typeId < 0
+}
+
+// IsEOS returns true if the given typeId declares that the end of stream has been reached.
+//
+// Otherwise returns false.
+func (typeId TypeIdType) IsEOS() bool {
+	return typeId == EOSTypeID
 }

--- a/host-go/engine/tests/wasm32_pipeline_with_state_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_with_state_test.go
@@ -1,0 +1,99 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/host-go/engine"
+	"github.com/lens-vm/lens/tests/modules"
+	"github.com/sourcenetwork/immutable/enumerable"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This test asserts how state can be shared between pipe stages if the same module-instance is
+// appended multiple times.
+func TestWasm32PipelineWithSharedState(t *testing.T) {
+	type Value struct {
+		Id   int
+		Name string
+	}
+	runtime := newRuntime()
+
+	module, err := engine.NewModule(runtime, modules.WasmPath5)
+	if err != nil {
+		t.Error(err)
+	}
+
+	instance, err := engine.NewInstance(module)
+	if err != nil {
+		t.Error(err)
+	}
+
+	source := enumerable.New([]Value{
+		{
+			Name: "John",
+		},
+		{
+			Name: "Shahzad",
+		},
+		{
+			Name: "Addo",
+		},
+	})
+
+	pipe := engine.Append[Value, Value](source, instance)
+	pipe = engine.Append[Value, Value](pipe, instance)
+	pipe = engine.Append[Value, Value](pipe, instance)
+
+	hasNext, err := pipe.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, hasNext)
+
+	val, err := pipe.Value()
+	require.Nil(t, err)
+	assert.Equal(t, Value{
+		// As the same module instance is shared 3 times, the counter will have been incremented
+		// 3 times, from a start point of 0
+		Id:   3,
+		Name: "John",
+	}, val)
+
+	hasNext, err = pipe.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, hasNext)
+
+	val, err = pipe.Value()
+	require.Nil(t, err)
+	assert.Equal(t, Value{
+		// As the same module instance is shared 3 times, the counter will have been incremented
+		// 3 times, from a start point of 3
+		Id:   6,
+		Name: "Shahzad",
+	}, val)
+
+	hasNext, err = pipe.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, hasNext)
+
+	val, err = pipe.Value()
+	require.Nil(t, err)
+	assert.Equal(t, Value{
+		// As the same module instance is shared 3 times, the counter will have been incremented
+		// 3 times, from a start point of 6
+		Id:   9,
+		Name: "Addo",
+	}, val)
+
+	hasNext, err = pipe.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.False(t, hasNext)
+}

--- a/host-go/engine/tests/wasm32_pipeline_with_state_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_with_state_test.go
@@ -53,7 +53,7 @@ func TestWasm32PipelineWithSharedState(t *testing.T) {
 	assert.True(t, hasNext)
 
 	val, err := pipe.Value()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, Value{
 		// As the same module instance is shared 3 times, the counter will have been incremented
 		// 3 times, from a start point of 0
@@ -68,7 +68,7 @@ func TestWasm32PipelineWithSharedState(t *testing.T) {
 	assert.True(t, hasNext)
 
 	val, err = pipe.Value()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, Value{
 		// As the same module instance is shared 3 times, the counter will have been incremented
 		// 3 times, from a start point of 3
@@ -83,7 +83,7 @@ func TestWasm32PipelineWithSharedState(t *testing.T) {
 	assert.True(t, hasNext)
 
 	val, err = pipe.Value()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, Value{
 		// As the same module instance is shared 3 times, the counter will have been incremented
 		// 3 times, from a start point of 6

--- a/host-go/go.mod
+++ b/host-go/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/lens-vm/lens/tests/modules v0.0.0-20230720125121-328ae81f5744
 	github.com/sourcenetwork/immutable v0.2.0
 	github.com/stretchr/testify v1.8.1
-	github.com/tetratelabs/wazero v1.3.1
+	github.com/tetratelabs/wazero v1.5.0
 	github.com/wasmerio/wasmer-go v1.0.4
 )
 

--- a/host-go/go.sum
+++ b/host-go/go.sum
@@ -19,6 +19,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tetratelabs/wazero v1.3.1 h1:rnb9FgOEQRLLR8tgoD1mfjNjMhFeWRUk+a4b4j/GpUM=
 github.com/tetratelabs/wazero v1.3.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.5.0 h1:Yz3fZHivfDiZFUXnWMPUoiW7s8tC1sjdBtlJn08qYa0=
+github.com/tetratelabs/wazero v1.5.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=
 github.com/wasmerio/wasmer-go v1.0.4/go.mod h1:0gzVdSfg6pysA6QVp6iVRPTagC6Wq9pOE8J86WKb2Fk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lens_sdk"
-version = "0.1.0"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -18,11 +18,17 @@ pub mod result;
 /// Error types returned by lens_sdk.
 pub mod error;
 
+/// Option type returned by lens_sdk.
+pub mod option;
+
 /// Alias for an sdk [Error](error/enum.Error.html).
 pub type Error = error::Error;
 
 /// Alias for an sdk [Result](result/type.Result.html).
 pub type Result<T> = result::Result<T>;
+
+/// Alias for an sdk [StreamOption](option/enum.StreamOption.html).
+pub type StreamOption<T> = option::StreamOption<T>;
 
 /// A type id that denotes a simple string-based error.
 ///
@@ -31,12 +37,21 @@ pub type Result<T> = result::Result<T>;
 /// handled accordingly.
 pub const ERROR_TYPE_ID: i8 = -1;
 
+/// A type id that denotes a nil value.
+pub const NIL_TYPE_ID: i8 = 0;
+
 /// A type id that denotes a json value.
 ///
 /// If present at the beginning of a byte array being read by a [lens host](https://github.com/lens-vm/lens#Hosts)
 /// or [try_from_mem](fn.try_from_mem.html), the byte array will be treated as a json value and will be
 /// handled accordingly.
 pub const JSON_TYPE_ID: i8 = 1;
+
+/// A type id that donates the end of stream.
+///
+/// If recieved it signals that the end of the stream has been reached and that the source will no longer yield
+/// new values.
+pub const EOS_TYPE_ID: i8 = i8::MAX;
 
 /// Returns a nil pointer.
 ///
@@ -59,6 +74,74 @@ pub fn alloc(size: usize) -> *mut u8 {
     return ptr;
 }
 
+/// Manually drop the memory of the given size at the given location.
+///
+/// It should only be called on pointers to manually managed memory.
+pub fn free(ptr: *mut u8, size: usize) {
+    let buf: Vec<u8> = unsafe {
+        Vec::from_raw_parts(ptr, size, size)
+    };
+    let buf = ManuallyDrop::new(buf);
+    mem::drop(ManuallyDrop::into_inner(buf));
+}
+
+/// Manually drop the memory occupied by a transport buffer at the given location.
+///
+/// Items are transported across the host-wasm boundary as manually managed memory buffers, the
+/// allocation for which is handled by [alloc](fn.alloc.html).  The pointer to this manually managed memory
+/// is returned by the `next` host function imported by LensVM wasm modules.
+///
+/// Once the item has been consumed by the transform, the memory allocated must be manually dropped,
+/// typically via this function.
+///
+/// # Safety
+///
+/// This function assumes that the pointer points to a transport buffer, passing a pointer to anything else
+/// will result in undefined behaviour.
+///
+/// The pointer should not be used after calling this function.  The memory it points to will have been unreserved,
+/// and may have been replaced by other stuff by the runtime.
+///
+/// # Errors
+///
+/// This function will return an [Error](error/enum.Error.html) if the data at the given location is not in the expected
+/// format.
+pub fn free_transport_buffer(ptr: *mut u8) -> Result<()> {
+    let type_vec: Vec<u8> = unsafe {
+        Vec::from_raw_parts(ptr, mem::size_of::<i8>(), mem::size_of::<i8>())
+    };
+
+    let type_rdr = Cursor::new(type_vec);
+    let mut type_rdr = ManuallyDrop::new(type_rdr);
+
+    let type_id: i8  = type_rdr.read_i8()?;
+    if type_id == NIL_TYPE_ID {
+        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        return Ok(())
+    }
+    if type_id == EOS_TYPE_ID {
+        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        return Ok(())
+    }
+    if type_id < 0 {
+        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        return Ok(())
+    }
+
+    let len_vec: Vec<u8> = unsafe {
+        Vec::from_raw_parts(ptr.add(mem::size_of::<i8>()), mem::size_of::<u32>(), mem::size_of::<u32>())
+    };
+
+    let len_rdr = Cursor::new(len_vec);
+    let mut len_rdr = ManuallyDrop::new(len_rdr);
+
+    let len: usize = len_rdr.read_u32::<LittleEndian>()?.try_into()?;
+
+    free(ptr, len);
+
+    Ok(())
+}
+
 /// Read the data held at the given location in memory as the given `TOutput` type.
 ///
 /// The bytes at the given location are expected to be in the correct format for the first (`type_id`) byte.
@@ -71,13 +154,15 @@ pub fn alloc(size: usize) -> *mut u8 {
 ///
 /// # Safety
 ///
-/// The memory at the given location will be disposed of on read.
+/// The pointer given to this function will typically be result of calls to the `next` host function imported by LensVM wasm modules.  It is
+/// manually managed memory, and once the result of this function is no longer needed (either due to having been processed, discarded, or copied),
+/// the pointer should be disposed of using [free_transport_buffer](fn.free_transport_buffer.html).
 ///
 /// # Errors
 ///
 /// This function will return an [Error](error/enum.Error.html) if the data at the given location is not in the expected
 /// format.
-pub fn try_from_mem<TOutput: for<'a> Deserialize<'a>>(ptr: *mut u8) -> Result<Option<TOutput>> {
+pub fn try_from_mem<TOutput: for<'a> Deserialize<'a>>(ptr: *mut u8) -> Result<StreamOption<TOutput>> {
     let type_vec: Vec<u8> = unsafe {
         Vec::from_raw_parts(ptr, mem::size_of::<i8>(), mem::size_of::<i8>())
     };
@@ -86,10 +171,16 @@ pub fn try_from_mem<TOutput: for<'a> Deserialize<'a>>(ptr: *mut u8) -> Result<Op
     let mut type_rdr = ManuallyDrop::new(type_rdr);
 
     let type_id: i8  = type_rdr.read_i8()?;
-    if type_id == 0 {
-        return Ok(None)
+    if type_id == NIL_TYPE_ID {
+        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        return Ok(StreamOption::None)
+    }
+    if type_id == EOS_TYPE_ID {
+        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        return Ok(StreamOption::EndOfStream)
     }
     if type_id < 0 {
+        mem::drop(ManuallyDrop::into_inner(type_rdr));
         return Result::from(error::LensError::InputErrorUnsupportedError)
     }
 
@@ -112,16 +203,10 @@ pub fn try_from_mem<TOutput: for<'a> Deserialize<'a>>(ptr: *mut u8) -> Result<Op
     // It is possible for null json values to reach this line, particularly if sourced directly
     // from a 3rd party module, so we ensure that we parse to option as well as the earlier type_id
     // checks.
-    let result = serde_json::from_str::<Option<TOutput>>(&json_string)?;
-
-    // Now that we have finished working in this func, we can construct the full input buffer
-    // and then manually drop it.
-    let buf_len = mem::size_of::<i8>() + mem::size_of::<u32>() + len;
-    let buf: Vec<u8> = unsafe {
-        Vec::from_raw_parts(ptr, buf_len, buf_len)
+    let result = match serde_json::from_str::<Option<TOutput>>(&json_string)? {
+        Some(v) => StreamOption::Some(v),
+        None => StreamOption::None,
     };
-    let buf = ManuallyDrop::new(buf);
-    mem::drop(ManuallyDrop::into_inner(buf));
 
     Ok(result)
 }
@@ -142,9 +227,14 @@ pub fn try_to_mem(type_id: i8, message: &[u8]) -> Result<*mut u8> {
     wtr.write_i8(type_id)?;
     wtr.set_position(mem::size_of::<i8>() as u64);
 
-    wtr.write_u32::<LittleEndian>(message.len() as u32)?;
-    wtr.set_position(mem::size_of::<i8>() as u64 + mem::size_of::<u32>() as u64);
-    wtr.write(message)?;
+    match type_id {
+        EOS_TYPE_ID => (),
+        _ => {
+            wtr.write_u32::<LittleEndian>(message.len() as u32)?;
+            wtr.set_position(mem::size_of::<i8>() as u64 + mem::size_of::<u32>() as u64);
+            wtr.write(message)?;
+        }
+    };
 
     let result = wtr.into_inner().clone().as_mut_ptr();
     Ok(result)

--- a/sdk-rust/src/option.rs
+++ b/sdk-rust/src/option.rs
@@ -1,0 +1,16 @@
+#[derive(Clone)]
+pub enum StreamOption<T> {
+    Some(T),
+    None,
+    EndOfStream,
+}
+
+impl <T> StreamOption<T> {
+    pub fn ok_or<E>(self, err: E) -> std::result::Result<T, E> {
+        match self {
+            StreamOption::Some(v) => Ok(v),
+            StreamOption::None => Err(err),
+            StreamOption::EndOfStream => Err(err),
+        }
+    }
+}

--- a/tests/integration/cli/with_len_change_test.go
+++ b/tests/integration/cli/with_len_change_test.go
@@ -1,0 +1,109 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/tests/modules"
+)
+
+func TestWithFilter(t *testing.T) {
+	type Value struct {
+		Name string
+		Type string `json:"__type"`
+	}
+
+	executeTest(
+		t,
+		TestCase[Value, Value]{
+			LensFile: `
+			{
+				"lenses": [
+					{
+						"path": "` + modules.WasmPath6 + `"
+					}
+				]
+			}`,
+			Input: []Value{
+				{
+					Name: "John",
+					Type: "pass",
+				},
+				{
+					Name: "Fred",
+					Type: "skip",
+				},
+				{
+					Name: "Orpheus",
+					Type: "pass",
+				},
+			},
+			ExpectedOutput: []Value{
+				{
+					Name: "John",
+					Type: "pass",
+				},
+				{
+					Name: "Orpheus",
+					Type: "pass",
+				},
+			},
+		},
+	)
+}
+
+func TestWithNormalize(t *testing.T) {
+	type Book struct {
+		Name        string
+		PageNumbers []int32
+	}
+	type Page struct {
+		BookName string
+		Number   int32
+	}
+
+	executeTest(
+		t,
+		TestCase[Book, Page]{
+			LensFile: `
+			{
+				"lenses": [
+					{
+						"path": "` + modules.WasmPath7 + `"
+					}
+				]
+			}`,
+			Input: []Book{
+				{
+					Name:        "The Tiger who came to tea",
+					PageNumbers: []int32{1, 2},
+				},
+				{
+					Name:        "The Elephant and the Balloon",
+					PageNumbers: []int32{157, 235, 384},
+				},
+			},
+			ExpectedOutput: []Page{
+				{
+					BookName: "The Tiger who came to tea",
+					Number:   1,
+				},
+				{
+					BookName: "The Tiger who came to tea",
+					Number:   2,
+				},
+				{
+					BookName: "The Elephant and the Balloon",
+					Number:   157,
+				},
+				{
+					BookName: "The Elephant and the Balloon",
+					Number:   235,
+				},
+				{
+					BookName: "The Elephant and the Balloon",
+					Number:   384,
+				},
+			},
+		},
+	)
+}

--- a/tests/integration/cli/with_modules_len_params_test.go
+++ b/tests/integration/cli/with_modules_len_params_test.go
@@ -1,0 +1,71 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/tests/modules"
+)
+
+func TestWithModulesWithNormalizeWithParams(t *testing.T) {
+	type Book struct {
+		Name        string
+		PageNumbers []int32
+	}
+	type Page struct {
+		BookName   string
+		PageNumber int32
+	}
+
+	executeTest(
+		t,
+		TestCase[Book, Page]{
+			LensFile: `
+			{
+				"lenses": [
+					{
+						"path": "` + modules.WasmPath7 + `"
+					},
+					{
+						"path": "` + modules.WasmPath4 + `",
+						"arguments": {
+							"src": "Number",
+							"dst": "PageNumber"
+						}
+					}
+				]
+			}`,
+			Input: []Book{
+				{
+					Name:        "The Tiger who came to tea",
+					PageNumbers: []int32{1, 2},
+				},
+				{
+					Name:        "The Elephant and the Balloon",
+					PageNumbers: []int32{157, 235, 384},
+				},
+			},
+			ExpectedOutput: []Page{
+				{
+					BookName:   "The Tiger who came to tea",
+					PageNumber: 1,
+				},
+				{
+					BookName:   "The Tiger who came to tea",
+					PageNumber: 2,
+				},
+				{
+					BookName:   "The Elephant and the Balloon",
+					PageNumber: 157,
+				},
+				{
+					BookName:   "The Elephant and the Balloon",
+					PageNumber: 235,
+				},
+				{
+					BookName:   "The Elephant and the Balloon",
+					PageNumber: 384,
+				},
+			},
+		},
+	)
+}

--- a/tests/integration/cli/with_state_test.go
+++ b/tests/integration/cli/with_state_test.go
@@ -1,0 +1,109 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/tests/modules"
+)
+
+func TestWithState(t *testing.T) {
+	type Value struct {
+		Id   int
+		Name string
+	}
+
+	executeTest(
+		t,
+		TestCase[Value, Value]{
+			LensFile: `
+			{
+				"lenses": [
+					{
+						"path": "` + modules.WasmPath5 + `"
+					}
+				]
+			}`,
+			Input: []Value{
+				{
+					Name: "John",
+				},
+				{
+					Name: "Fred",
+				},
+				{
+					Name: "Orpheus",
+				},
+			},
+			ExpectedOutput: []Value{
+				{
+					Id:   1,
+					Name: "John",
+				},
+				{
+					Id:   2,
+					Name: "Fred",
+				},
+				{
+					Id:   3,
+					Name: "Orpheus",
+				},
+			},
+		},
+	)
+}
+
+// As the configuration will spin up an instance per lens, the state will not be shared between
+// them by default and the resultant Ids will be the same as if only a single lens was specified.
+func TestWithStateDuplicated(t *testing.T) {
+	type Value struct {
+		Id   int
+		Name string
+	}
+
+	executeTest(
+		t,
+		TestCase[Value, Value]{
+			LensFile: `
+			{
+				"lenses": [
+					{
+						"path": "` + modules.WasmPath5 + `"
+					},
+					{
+						"path": "` + modules.WasmPath5 + `"
+					},
+					{
+						"path": "` + modules.WasmPath5 + `"
+					}
+				]
+			}`,
+			Input: []Value{
+				{
+					Name: "John",
+				},
+				{
+					Name: "Fred",
+				},
+				{
+					Name: "Orpheus",
+				},
+			},
+			ExpectedOutput: []Value{
+				{
+					Id:   1,
+					Name: "John",
+				},
+				{
+					Id:   2,
+					Name: "Fred",
+				},
+				{
+					Id:   3,
+					Name: "Orpheus",
+				},
+			},
+		},
+	)
+}
+
+// todo - add tests that split a single record into many

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -8,4 +8,7 @@ build:
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_simple/Cargo.toml"
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_simple2/Cargo.toml"
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_rename/Cargo.toml"
+	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_counter/Cargo.toml"
+	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_filter/Cargo.toml"
+	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_normalize/Cargo.toml"
 	(cd "./as_wasm32_simple/" && npm install && npm run asbuild:debug)

--- a/tests/modules/as_wasm32_simple/assembly/index.ts
+++ b/tests/modules/as_wasm32_simple/assembly/index.ts
@@ -20,10 +20,7 @@ function abort(
 const JSON_TYPE_ID: i8 = 1;
 
 export function alloc(size: usize): usize {
-    let buf = new ArrayBuffer(i32(size));
-    let ptr = changetype<usize>(buf);
-    store<ArrayBuffer>(ptr, buf);
-    return ptr;
+    return heap.alloc(size);
 }
 
 export function transform(ptr: usize): usize {

--- a/tests/modules/as_wasm32_simple/assembly/index.ts
+++ b/tests/modules/as_wasm32_simple/assembly/index.ts
@@ -2,7 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { JSON, JSONEncoder } from "assemblyscript-json"; 
+import { JSON, JSONEncoder } from "assemblyscript-json";
+
+@external("lens", "next")
+export declare function next(): usize
 
 // AssemblyScript demands that an abort func exists, so we define our own here and ask the compiler to use it
 // instead of an import (see asconfig.json "use" flag), and https://www.assemblyscript.org/concepts.html#special-imports
@@ -17,15 +20,32 @@ function abort(
     unreachable()
 }
 
+class StreamOption {
+    json: String
+    endOfStream: bool
+
+    constructor(json: String, endOfStream: bool) {
+        this.json = json;
+        this.endOfStream = endOfStream;
+    }
+}
+
 const JSON_TYPE_ID: i8 = 1;
+const EOS_TYPE_ID: i8 = 127;
 
 export function alloc(size: usize): usize {
     return heap.alloc(size);
 }
 
-export function transform(ptr: usize): usize {
-    let inputStr = fromTransportVec(ptr)
-    let inputJsonObj = <JSON.Obj>(JSON.parse(inputStr));
+export function transform(): usize {
+    let ptr = next();
+    let streamOption = fromTransportVec(ptr)
+    if (streamOption.endOfStream) {
+        heap.free(ptr)
+        return toTransportVec(EOS_TYPE_ID, "");
+    }
+
+    let inputJsonObj = <JSON.Obj>(JSON.parse(streamOption.json));
 
     let inputName = inputJsonObj.getString("FullName");
     let inputAge = inputJsonObj.getInteger("Age");
@@ -40,13 +60,19 @@ export function transform(ptr: usize): usize {
     }
     encoder.popObject()
 
-    return toTransportVec(JSON_TYPE_ID, encoder.toString());
+    let resultPtr = toTransportVec(JSON_TYPE_ID, encoder.toString());
+    // Free the input data once we are done processing
+    heap.free(ptr)
+    return resultPtr
 }
 
-function fromTransportVec(ptr: usize): string {
+function fromTransportVec(ptr: usize): StreamOption {
     let type = load<i8>(ptr)
+    if (type == EOS_TYPE_ID) {
+        return new StreamOption("", true)
+    }
     let len = load<u32>(ptr+1)
-    return String.UTF8.decodeUnsafe(ptr+1+4, len, false)
+    return new StreamOption(String.UTF8.decodeUnsafe(ptr+1+4, len, false), false)
 }
 
 function toTransportVec(type_id: i8, message: string): usize {
@@ -54,10 +80,17 @@ function toTransportVec(type_id: i8, message: string): usize {
 
     let buf = new Uint8Array(len+1+4);
     let ptr = changetype<usize>(buf);
-    store<i8>(ptr, len);
-    store<u32>(ptr+1, len);
+    store<i8>(ptr, type_id);
 
-    String.UTF8.encodeUnsafe(changetype<usize>(message), len, ptr+1+4, false)
+    switch (type_id) {
+        case EOS_TYPE_ID:
+            // // no-op - End of stream messages have no value component that needs writing
+            break;
+
+        default:
+            store<u32>(ptr+1, len);
+            String.UTF8.encodeUnsafe(changetype<usize>(message), len, ptr+1+4, false)
+    }
 
     return ptr
 }

--- a/tests/modules/rust_wasm32_counter/Cargo.toml
+++ b/tests/modules/rust_wasm32_counter/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rust-wasm32-counter"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.87"
+atomic-counter = "1.0.1"
+once_cell = "1.16.0"
+lens_sdk = { path = "../../../sdk-rust" }

--- a/tests/modules/rust_wasm32_counter/src/lib.rs
+++ b/tests/modules/rust_wasm32_counter/src/lib.rs
@@ -1,9 +1,7 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 use std::error::Error;
 use serde::{Serialize, Deserialize};
+use atomic_counter::{AtomicCounter, RelaxedCounter};
+use once_cell::sync::Lazy;
 use lens_sdk::StreamOption;
 use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
@@ -14,11 +12,13 @@ extern "C" {
 
 #[derive(Serialize, Deserialize)]
 pub struct Value {
-    #[serde(rename = "FullName")]
+    #[serde(rename = "Id")]
+	pub id: usize,
+    #[serde(rename = "Name")]
     pub name: String,
-    #[serde(rename = "Age")]
-	pub age: i64,
 }
+
+static COUNTER: Lazy<RelaxedCounter> = Lazy::new(|| RelaxedCounter::new(0));
 
 #[no_mangle]
 pub extern fn alloc(size: usize) -> *mut u8 {
@@ -46,41 +46,12 @@ fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
         None => return Ok(None),
         EndOfStream => return Ok(EndOfStream),
     };
-    
-    let result = Value {
-        name: input.name,
-        age: input.age + 1,
-    };
-    
-    let result_json = serde_json::to_vec(&result)?;
-    Ok(Some(result_json))
-}
 
-#[no_mangle]
-pub extern fn inverse() -> *mut u8 {
-    match try_inverse() {
-        Ok(o) => match o {
-            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            None => lens_sdk::nil_ptr(),
-            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
-        },
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_inverse() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
-    let ptr = unsafe { next() };
-    let input = match lens_sdk::try_from_mem::<Value>(ptr)? {
-        Some(v) => v,
-        // Implementations of `transform` are free to handle nil however they like. In this
-        // implementation we chose to return nil given a nil input.
-        None => return Ok(None),
-        EndOfStream => return Ok(EndOfStream),
-    };
+    COUNTER.inc();
 
     let result = Value {
+        id: COUNTER.get(),
         name: input.name,
-        age: input.age - 1,
     };
 
     let result_json = serde_json::to_vec(&result)?;

--- a/tests/modules/rust_wasm32_filter/Cargo.toml
+++ b/tests/modules/rust_wasm32_filter/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust-wasm32-filter"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.87"
+lens_sdk = { path = "../../../sdk-rust" }

--- a/tests/modules/rust_wasm32_filter/src/lib.rs
+++ b/tests/modules/rust_wasm32_filter/src/lib.rs
@@ -1,0 +1,53 @@
+use std::error::Error;
+use serde::{Serialize, Deserialize};
+use lens_sdk::StreamOption;
+use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
+
+#[link(wasm_import_module = "lens")]
+extern "C" {
+    fn next() -> *mut u8;
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Value {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "__type")]
+	pub type_name: String,
+}
+
+#[no_mangle]
+pub extern fn alloc(size: usize) -> *mut u8 {
+    lens_sdk::alloc(size)
+}
+
+#[no_mangle]
+pub extern fn transform() -> *mut u8 {
+    match try_transform() {
+        Ok(o) => match o {
+            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
+            None => lens_sdk::nil_ptr(),
+            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
+        },
+        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
+    }
+}
+
+fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
+    loop {
+        let ptr = unsafe { next() };
+        let input = match lens_sdk::try_from_mem::<Value>(ptr)? {
+            Some(v) => v,
+            // Implementations of `transform` are free to handle nil however they like. In this
+            // implementation we chose to return nil given a nil input.
+            None => return Ok(None),
+            EndOfStream => return Ok(EndOfStream),
+        };
+
+        if input.type_name == "pass" {
+            let result_json = serde_json::to_vec(&input)?;
+            return Ok(Some(result_json))
+        }
+        lens_sdk::free_transport_buffer(ptr)?;
+    }
+}

--- a/tests/modules/rust_wasm32_normalize/Cargo.toml
+++ b/tests/modules/rust_wasm32_normalize/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rust-wasm32-normalize"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.87"
+once_cell = "1.16.0"
+lens_sdk = { path = "../../../sdk-rust" }

--- a/tests/modules/rust_wasm32_normalize/src/lib.rs
+++ b/tests/modules/rust_wasm32_normalize/src/lib.rs
@@ -1,0 +1,79 @@
+use std::error::Error;
+use std::collections::VecDeque;
+use std::sync::RwLock;
+use serde::{Serialize, Deserialize};
+use once_cell::sync::Lazy;
+use lens_sdk::StreamOption;
+use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
+
+#[link(wasm_import_module = "lens")]
+extern "C" {
+    fn next() -> *mut u8;
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Book {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "PageNumbers")]
+	pub page_numbers: Vec<i32>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Page {
+    #[serde(rename = "BookName")]
+    pub book_name: String,
+    #[serde(rename = "Number")]
+	pub number: i32,
+}
+
+static PENDING_PAGES: RwLock<Lazy<VecDeque<Page>>> = RwLock::new(Lazy::new(|| VecDeque::new()));
+
+#[no_mangle]
+pub extern fn alloc(size: usize) -> *mut u8 {
+    lens_sdk::alloc(size)
+}
+
+#[no_mangle]
+pub extern fn transform() -> *mut u8 {
+    match try_transform() {
+        Ok(o) => match o {
+            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json.clone()),
+            None => lens_sdk::nil_ptr(),
+            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
+        },
+        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
+    }
+}
+
+fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
+    let mut pending_pages = PENDING_PAGES.write()?;
+
+    if pending_pages.len() == 0 {
+        let ptr = unsafe { next() };
+        let input = match lens_sdk::try_from_mem::<Book>(ptr)? {
+            Some(v) => v,
+            // Implementations of `transform` are free to handle nil however they like. In this
+            // implementation we chose to return nil given a nil input.
+            None => return Ok(None),
+            EndOfStream => return Ok(EndOfStream),
+        };
+
+        for page_number in input.page_numbers {
+            let page = Page {
+                book_name: input.name.clone(),
+                number: page_number,
+            };
+            pending_pages.push_back(page);
+        }
+        lens_sdk::free_transport_buffer(ptr)?;
+    }
+
+    if pending_pages.len() > 0 {
+        let result = pending_pages.pop_front();
+        let result_json = serde_json::to_vec(&result)?;
+        return Ok(Some(result_json));
+    }
+
+    Ok(None)
+}

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -7,6 +7,13 @@ use std::sync::RwLock;
 use std::error::Error;
 use std::{fmt, error};
 use serde::Deserialize;
+use lens_sdk::StreamOption;
+use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
+
+#[link(wasm_import_module = "lens")]
+extern "C" {
+    fn next() -> *mut u8;
+}
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 enum ModuleError {
@@ -32,7 +39,7 @@ pub struct Parameters {
     pub dst: String,
 }
 
-static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
+static PARAMETERS: RwLock<StreamOption<Parameters>> = RwLock::new(None);
 
 #[no_mangle]
 pub extern fn alloc(size: usize) -> *mut u8 {
@@ -57,22 +64,25 @@ fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
 }
 
 #[no_mangle]
-pub extern fn transform(ptr: *mut u8) -> *mut u8 {
-    match try_transform(ptr) {
+pub extern fn transform() -> *mut u8 {
+    match try_transform() {
         Ok(o) => match o {
             Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
             None => lens_sdk::nil_ptr(),
+            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
         },
         Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
     }
 }
 
-fn try_transform(ptr: *mut u8) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
+fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
+    let ptr = unsafe { next() };
     let mut input = match lens_sdk::try_from_mem::<HashMap<String, serde_json::Value>>(ptr)? {
         Some(v) => v,
         // Implementations of `transform` are free to handle nil however they like. In this
         // implementation we chose to return nil given a nil input.
         None => return Ok(None),
+        EndOfStream => return Ok(EndOfStream)
     };
 
     let params = PARAMETERS.read()?
@@ -88,5 +98,6 @@ fn try_transform(ptr: *mut u8) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
     input.insert(params.dst, value);
     
     let result_json = serde_json::to_vec(&input)?;
+    lens_sdk::free_transport_buffer(ptr)?;
     Ok(Some(result_json))
 }

--- a/tests/modules/rust_wasm32_simple/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple/src/lib.rs
@@ -4,6 +4,13 @@
 
 use std::error::Error;
 use serde::{Serialize, Deserialize};
+use lens_sdk::StreamOption;
+use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
+
+#[link(wasm_import_module = "lens")]
+extern "C" {
+    fn next() -> *mut u8;
+}
 
 #[derive(Deserialize)]
 pub struct Input {
@@ -27,22 +34,25 @@ pub extern fn alloc(size: usize) -> *mut u8 {
 }
 
 #[no_mangle]
-pub extern fn transform(ptr: *mut u8) -> *mut u8 {
-    match try_transform(ptr) {
+pub extern fn transform() -> *mut u8 {
+    match try_transform() {
         Ok(o) => match o {
             Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
             None => lens_sdk::nil_ptr(),
+            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
         },
         Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
     }
 }
 
-fn try_transform(ptr: *mut u8) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
+fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
+    let ptr = unsafe { next() };
     let input = match lens_sdk::try_from_mem::<Input>(ptr)? {
         Some(v) => v,
         // Implementations of `transform` are free to handle nil however they like. In this
         // implementation we chose to return nil given a nil input.
         None => return Ok(None),
+        EndOfStream => return Ok(EndOfStream)
     };
     
     let result = Output {
@@ -51,5 +61,6 @@ fn try_transform(ptr: *mut u8) -> Result<Option<Vec<u8>>, Box<dyn Error>> {
     };
     
     let result_json = serde_json::to_vec(&result)?;
+    lens_sdk::free_transport_buffer(ptr)?;
     Ok(Some(result_json))
 }

--- a/tests/modules/utils.go
+++ b/tests/modules/utils.go
@@ -31,6 +31,21 @@ var WasmPath4 string = getPathRelativeToProjectRoot(
 	"/tests/modules/rust_wasm32_rename/target/wasm32-unknown-unknown/debug/rust_wasm32_rename.wasm",
 )
 
+// WasmPath5 contains a wasm32 rust lens that sets an id using a counter.
+var WasmPath5 string = getPathRelativeToProjectRoot(
+	"/tests/modules/rust_wasm32_counter/target/wasm32-unknown-unknown/debug/rust_wasm32_counter.wasm",
+)
+
+// WasmPath6 contains a wasm32 rust lens that only returns values where `__type` == "pass".
+var WasmPath6 string = getPathRelativeToProjectRoot(
+	"/tests/modules/rust_wasm32_filter/target/wasm32-unknown-unknown/debug/rust_wasm32_filter.wasm",
+)
+
+// WasmPath7 contains a wasm32 rust lens that turns books into multiple pages.
+var WasmPath7 string = getPathRelativeToProjectRoot(
+	"/tests/modules/rust_wasm32_normalize/target/wasm32-unknown-unknown/debug/rust_wasm32_normalize.wasm",
+)
+
 func getPathRelativeToProjectRoot(relativePath string) string {
 	_, filename, _, _ := runtime.Caller(0)
 	root := path.Dir(path.Dir(path.Dir(filename)))


### PR DESCRIPTION
Resolves #5 #62

Makes wasm modules enumerable.  This breaks the one input to one output restriction and allows for a much broader range of operations.

Tests have been included for three common scenarios now possible - aggregation, filtering and normalization.  It also provides a mechanic by which state can be shared between multiple pipeline-stages by reusing the same module instance - this is not exposed via the config yet, but it would be easy to do so.

Filtering and normalization will be particularly powerful once #9 is implemented - e.g. a large table could be broken up and different transforms could be applied based on type.

## Known issues

- Wazero suffers from https://github.com/lens-vm/lens/issues/71 - I cannot find a way to get this to work with the runtime, and I do not think it is worth blocking this PR for it. Otherwise thanks to Keenan's help the wazero runtime still works. 
