### PR TITLE
feat: Add wazero wasm runtime

### DIFF
--- a/host-go/config/config.go
+++ b/host-go/config/config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/lens-vm/lens/host-go/config/model"
 	"github.com/lens-vm/lens/host-go/engine"
 	"github.com/lens-vm/lens/host-go/engine/module"
-	"github.com/lens-vm/lens/host-go/runtimes/wasmer"
+	"github.com/lens-vm/lens/host-go/runtimes/wazero"
 	"github.com/sourcenetwork/immutable/enumerable"
 )
 
@@ -31,7 +31,7 @@ func LoadFromFile[TSource any, TResult any](path string, src enumerable.Enumerab
 //
 // It does not enumerate the src.
 func Load[TSource any, TResult any](lensConfig model.Lens, src enumerable.Enumerable[TSource]) (enumerable.Enumerable[TResult], error) {
-	runtime := wasmer.New()
+	runtime := wazero.New()
 	modulesByPath := map[string]module.Module{}
 
 	return LoadInto[TSource, TResult](runtime, modulesByPath, lensConfig, src)

--- a/host-go/engine/tests/wasm32_pipeline_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/lens-vm/lens/host-go/engine"
-	"github.com/lens-vm/lens/host-go/runtimes/wasmer"
+	"github.com/lens-vm/lens/host-go/runtimes/wazero"
 	"github.com/lens-vm/lens/tests/modules"
 	"github.com/sourcenetwork/immutable/enumerable"
 
@@ -17,7 +17,7 @@ import (
 )
 
 func TestWasm32PipelineFromSourceAsFull(t *testing.T) {
-	runtime := wasmer.New()
+	runtime := wazero.New()
 
 	module, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {
@@ -58,7 +58,7 @@ func TestWasm32PipelineFromSourceAsFull(t *testing.T) {
 }
 
 func TestWasm32PipelineFromSourceAsFullToModuleAsFull(t *testing.T) {
-	runtime := wasmer.New()
+	runtime := wazero.New()
 
 	module1, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {
@@ -109,7 +109,7 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFull(t *testing.T) {
 }
 
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFull(t *testing.T) {
-	runtime := wasmer.New()
+	runtime := wazero.New()
 
 	module1, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {
@@ -161,7 +161,7 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFull(t *testing.T
 }
 
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToASModuleAsFull(t *testing.T) {
-	runtime := wasmer.New()
+	runtime := wazero.New()
 
 	module1, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {
@@ -220,7 +220,7 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFullToASModuleAsFull(t *testing
 }
 
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFullWithSingleAppend(t *testing.T) {
-	runtime := wasmer.New()
+	runtime := wazero.New()
 
 	module1, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {

--- a/host-go/engine/tests/wasm32_pipeline_with_params_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_with_params_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/lens-vm/lens/host-go/engine"
-	"github.com/lens-vm/lens/host-go/runtimes/wasmer"
+	"github.com/lens-vm/lens/host-go/runtimes/wazero"
 	"github.com/lens-vm/lens/tests/modules"
 	"github.com/sourcenetwork/immutable/enumerable"
 
@@ -17,7 +17,7 @@ import (
 )
 
 func TestWasm32PipelineWithAddtionalParams(t *testing.T) {
-	runtime := wasmer.New()
+	runtime := wazero.New()
 
 	module, err := engine.NewModule(runtime, modules.WasmPath4)
 	if err != nil {
@@ -64,7 +64,7 @@ func TestWasm32PipelineWithAddtionalParams(t *testing.T) {
 }
 
 func TestWasm32PipelineMultipleModulesAndWithAddtionalParams(t *testing.T) {
-	runtime := wasmer.New()
+	runtime := wazero.New()
 
 	module, err := engine.NewModule(runtime, modules.WasmPath4)
 	if err != nil {
@@ -126,7 +126,7 @@ func TestWasm32PipelineMultipleModulesAndWithAddtionalParams(t *testing.T) {
 }
 
 func TestWasm32PipelineWithAddtionalParamsErrors(t *testing.T) {
-	runtime := wasmer.New()
+	runtime := wazero.New()
 
 	module, err := engine.NewModule(runtime, modules.WasmPath4)
 	if err != nil {
@@ -163,7 +163,7 @@ func TestWasm32PipelineWithAddtionalParamsErrors(t *testing.T) {
 }
 
 func TestWasm32PipelineWithAddtionalParamsErrorsAndNilItem(t *testing.T) {
-	runtime := wasmer.New()
+	runtime := wazero.New()
 
 	module, err := engine.NewModule(runtime, modules.WasmPath4)
 	if err != nil {

--- a/host-go/go.mod
+++ b/host-go/go.mod
@@ -3,13 +3,15 @@ module github.com/lens-vm/lens/host-go
 go 1.18
 
 require (
+	github.com/lens-vm/lens/tests/modules v0.0.0-20230720125121-328ae81f5744
+	github.com/sourcenetwork/immutable v0.2.0
 	github.com/stretchr/testify v1.8.1
+	github.com/tetratelabs/wazero v1.3.1
 	github.com/wasmerio/wasmer-go v1.0.4
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sourcenetwork/immutable v0.2.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/host-go/go.sum
+++ b/host-go/go.sum
@@ -1,10 +1,10 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/lens-vm/lens/tests/modules v0.0.0-20230720125121-328ae81f5744 h1:EVDvaBqPx+6TGzT69Ef7N+svalt8R2VtDAyfhtZomJs=
+github.com/lens-vm/lens/tests/modules v0.0.0-20230720125121-328ae81f5744/go.mod h1:las0vk7izj/E8fAZEmbZ7PpoSoziD7/4wnlVlzXJ8bA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sourcenetwork/immutable v0.1.0 h1:0ZJ5Au1/6yzzjhDg5TO+h3dYHTdA1fVvRRt9a4UQzwg=
-github.com/sourcenetwork/immutable v0.1.0/go.mod h1:4jpxObkIQw8pvlIRm4ndZqf3pH9ZjYEw/UYI6GZDJww=
 github.com/sourcenetwork/immutable v0.2.0 h1:yz5oxFFbcI70+rKJxFINVtiKqiLXx3xIzGrdDRTUZWg=
 github.com/sourcenetwork/immutable v0.2.0/go.mod h1:4jpxObkIQw8pvlIRm4ndZqf3pH9ZjYEw/UYI6GZDJww=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -15,8 +15,11 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tetratelabs/wazero v1.3.1 h1:rnb9FgOEQRLLR8tgoD1mfjNjMhFeWRUk+a4b4j/GpUM=
+github.com/tetratelabs/wazero v1.3.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=
 github.com/wasmerio/wasmer-go v1.0.4/go.mod h1:0gzVdSfg6pysA6QVp6iVRPTagC6Wq9pOE8J86WKb2Fk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/host-go/runtimes/wazero/runtime.go
+++ b/host-go/runtimes/wazero/runtime.go
@@ -1,0 +1,136 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package wazero
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/lens-vm/lens/host-go/engine/module"
+	"github.com/lens-vm/lens/host-go/engine/pipes"
+	"github.com/tetratelabs/wazero"
+)
+
+type wRuntime struct {
+	runtime wazero.Runtime
+}
+
+var _ module.Runtime = (*wRuntime)(nil)
+
+func New() module.Runtime {
+	ctx := context.TODO()
+	return &wRuntime{
+		runtime: wazero.NewRuntime(ctx),
+	}
+}
+
+type wModule struct {
+	runtime wazero.Runtime
+	module  wazero.CompiledModule
+}
+
+var _ module.Module = (*wModule)(nil)
+
+func (rt *wRuntime) NewModule(wasmBytes []byte) (module.Module, error) {
+	ctx := context.TODO()
+	compiledWasm, err := rt.runtime.CompileModule(ctx, wasmBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &wModule{
+		runtime: rt.runtime,
+		module:  compiledWasm,
+	}, nil
+}
+
+func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) (module.Instance, error) {
+	ctx := context.TODO()
+	instance, err := m.runtime.InstantiateModule(ctx, m.module, wazero.NewModuleConfig().WithName(""))
+
+	memory := instance.ExportedMemory("memory")
+	if memory == nil {
+		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "memory"))
+	}
+
+	alloc := instance.ExportedFunction("alloc")
+	if alloc == nil {
+		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "alloc"))
+	}
+
+	transform := instance.ExportedFunction(functionName)
+	if transform == nil {
+		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", functionName))
+	}
+
+	params := map[string]any{}
+	// Merge the param sets into a single map in case more than
+	// one map is provided.
+	for _, paramSet := range paramSets {
+		for key, value := range paramSet {
+			params[key] = value
+		}
+	}
+
+	if len(params) > 0 {
+		setParam := instance.ExportedFunction("set_param")
+		if err != nil {
+			return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "set_param"))
+		}
+
+		sourceBytes, err := json.Marshal(params)
+		if err != nil {
+			return module.Instance{}, err
+		}
+
+		index, err := alloc.Call(ctx, uint64(module.TypeIdSize+module.MemSize(len(sourceBytes))+module.LenSize))
+		if err != nil {
+			return module.Instance{}, err
+		}
+
+		data, _ := memory.Read(0, memory.Size())
+		err = pipes.WriteItem(module.JSONTypeID, sourceBytes, data[index[0]:])
+		if err != nil {
+			return module.Instance{}, err
+		}
+
+		r, err := setParam.Call(ctx, index[0])
+		if err != nil {
+			return module.Instance{}, err
+		}
+
+		data, _ = memory.Read(0, memory.Size())
+		// The `set_param` wasm function may error, in which case the error needs to be retrieved
+		// from memory using `pipes.GetItem`.
+		_, err = pipes.GetItem(data, module.MemSize(r[0]))
+		if err != nil {
+			return module.Instance{}, err
+		}
+	}
+
+	return module.Instance{
+		Alloc: func(u module.MemSize) (module.MemSize, error) {
+			r, err := alloc.Call(ctx, uint64(u))
+			if err != nil {
+				return 0, err
+			}
+			return module.MemSize(r[0]), nil
+		},
+		Transform: func(u module.MemSize) (module.MemSize, error) {
+			r, err := transform.Call(ctx, uint64(u))
+			if err != nil {
+				return 0, err
+			}
+			return module.MemSize(r[0]), nil
+		},
+		GetData: func() []byte {
+			data, _ := memory.Read(0, memory.Size())
+			return data
+		},
+		OwnedBy: instance,
+	}, nil
+}


### PR DESCRIPTION
Resolves #51 

Takes a few short cuts, as I have to run back home for Farsi class and this is hopefully going to unblock the release.

Passes `make test`.

Shortcuts taken:
- I just swapped out wasmer in the tests, so now wasmer is untested - we should of course be testing both
- The error messages are individually copy pasted from wasmer, they should be tidied up
- context.Todo everywhere
- According to the interfaces a few slice[0] calls can theoretically panic, but I do not think it is possible with valid lens modules