### PR TITLE
refactor: Use util func to init test runtime

### DIFF
--- a/host-go/engine/tests/utils.go
+++ b/host-go/engine/tests/utils.go
@@ -4,6 +4,11 @@
 
 package tests
 
+import (
+	"github.com/lens-vm/lens/host-go/engine/module"
+	"github.com/lens-vm/lens/host-go/runtimes/wazero"
+)
+
 type type1 struct {
 	Name string
 	Age  int
@@ -12,4 +17,8 @@ type type1 struct {
 type type2 struct {
 	FullName string
 	Age      int
+}
+
+func newRuntime() module.Runtime {
+	return wazero.New()
 }

--- a/host-go/engine/tests/wasm32_pipeline_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/lens-vm/lens/host-go/engine"
-	"github.com/lens-vm/lens/host-go/runtimes/wazero"
 	"github.com/lens-vm/lens/tests/modules"
 	"github.com/sourcenetwork/immutable/enumerable"
 
@@ -17,7 +16,7 @@ import (
 )
 
 func TestWasm32PipelineFromSourceAsFull(t *testing.T) {
-	runtime := wazero.New()
+	runtime := newRuntime()
 
 	module, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {
@@ -58,7 +57,7 @@ func TestWasm32PipelineFromSourceAsFull(t *testing.T) {
 }
 
 func TestWasm32PipelineFromSourceAsFullToModuleAsFull(t *testing.T) {
-	runtime := wazero.New()
+	runtime := newRuntime()
 
 	module1, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {
@@ -109,7 +108,7 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFull(t *testing.T) {
 }
 
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFull(t *testing.T) {
-	runtime := wazero.New()
+	runtime := newRuntime()
 
 	module1, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {
@@ -161,7 +160,7 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFull(t *testing.T
 }
 
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToASModuleAsFull(t *testing.T) {
-	runtime := wazero.New()
+	runtime := newRuntime()
 
 	module1, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {
@@ -220,7 +219,7 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFullToASModuleAsFull(t *testing
 }
 
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFullWithSingleAppend(t *testing.T) {
-	runtime := wazero.New()
+	runtime := newRuntime()
 
 	module1, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {

--- a/host-go/engine/tests/wasm32_pipeline_with_params_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_with_params_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/lens-vm/lens/host-go/engine"
-	"github.com/lens-vm/lens/host-go/runtimes/wazero"
 	"github.com/lens-vm/lens/tests/modules"
 	"github.com/sourcenetwork/immutable/enumerable"
 
@@ -17,7 +16,7 @@ import (
 )
 
 func TestWasm32PipelineWithAddtionalParams(t *testing.T) {
-	runtime := wazero.New()
+	runtime := newRuntime()
 
 	module, err := engine.NewModule(runtime, modules.WasmPath4)
 	if err != nil {
@@ -64,7 +63,7 @@ func TestWasm32PipelineWithAddtionalParams(t *testing.T) {
 }
 
 func TestWasm32PipelineMultipleModulesAndWithAddtionalParams(t *testing.T) {
-	runtime := wazero.New()
+	runtime := newRuntime()
 
 	module, err := engine.NewModule(runtime, modules.WasmPath4)
 	if err != nil {
@@ -126,7 +125,7 @@ func TestWasm32PipelineMultipleModulesAndWithAddtionalParams(t *testing.T) {
 }
 
 func TestWasm32PipelineWithAddtionalParamsErrors(t *testing.T) {
-	runtime := wazero.New()
+	runtime := newRuntime()
 
 	module, err := engine.NewModule(runtime, modules.WasmPath4)
 	if err != nil {
@@ -163,7 +162,7 @@ func TestWasm32PipelineWithAddtionalParamsErrors(t *testing.T) {
 }
 
 func TestWasm32PipelineWithAddtionalParamsErrorsAndNilItem(t *testing.T) {
-	runtime := wazero.New()
+	runtime := newRuntime()
 
 	module, err := engine.NewModule(runtime, modules.WasmPath4)
 	if err != nil {


### PR DESCRIPTION
Resolves #54 

Uses a new test util func to init test runtime instead of hardcoding it in each test individually.

This should make it quite easy to change the runtime used for tests in the future, either via env var, or simply by changing the hardcoded value. 

Note: I'm not excluding Keenan from reviewing this, but I don't seem to be able to add his user atm - he has not yet accepted the collaboration invite.