### PR TITLE
feat: Add wasmtime runtime

### DIFF
--- a/host-go/config/config.go
+++ b/host-go/config/config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/lens-vm/lens/host-go/config/model"
 	"github.com/lens-vm/lens/host-go/engine"
 	"github.com/lens-vm/lens/host-go/engine/module"
-	"github.com/lens-vm/lens/host-go/runtimes/wazero"
+	"github.com/lens-vm/lens/host-go/runtimes/wasmtime"
 	"github.com/sourcenetwork/immutable/enumerable"
 )
 
@@ -31,7 +31,7 @@ func LoadFromFile[TSource any, TResult any](path string, src enumerable.Enumerab
 //
 // It does not enumerate the src.
 func Load[TSource any, TResult any](lensConfig model.Lens, src enumerable.Enumerable[TSource]) (enumerable.Enumerable[TResult], error) {
-	runtime := wazero.New()
+	runtime := wasmtime.New()
 	modulesByPath := map[string]module.Module{}
 
 	return LoadInto[TSource, TResult](runtime, modulesByPath, lensConfig, src)

--- a/host-go/engine/tests/utils.go
+++ b/host-go/engine/tests/utils.go
@@ -6,7 +6,7 @@ package tests
 
 import (
 	"github.com/lens-vm/lens/host-go/engine/module"
-	"github.com/lens-vm/lens/host-go/runtimes/wazero"
+	"github.com/lens-vm/lens/host-go/runtimes/wasmtime"
 )
 
 type type1 struct {
@@ -20,5 +20,5 @@ type type2 struct {
 }
 
 func newRuntime() module.Runtime {
-	return wazero.New()
+	return wasmtime.New()
 }

--- a/host-go/go.mod
+++ b/host-go/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/bytecodealliance/wasmtime-go/v14 v14.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/host-go/go.sum
+++ b/host-go/go.sum
@@ -1,3 +1,5 @@
+github.com/bytecodealliance/wasmtime-go/v14 v14.0.0 h1:ur7S3P+PAeJmgllhSrKnGQOAmmtUbLQxb/nw2NZiaEM=
+github.com/bytecodealliance/wasmtime-go/v14 v14.0.0/go.mod h1:tqOVEUjnXY6aGpSfM9qdVRR6G//Yc513fFYUdzZb/DY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -21,6 +23,7 @@ github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmx
 github.com/wasmerio/wasmer-go v1.0.4/go.mod h1:0gzVdSfg6pysA6QVp6iVRPTagC6Wq9pOE8J86WKb2Fk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/host-go/runtimes/wasmtime/runtime.go
+++ b/host-go/runtimes/wasmtime/runtime.go
@@ -61,7 +61,7 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 	}
 
 	memory := mem.Memory()
-	if mem == nil {
+	if memory == nil {
 		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "memory"))
 	}
 

--- a/host-go/runtimes/wasmtime/runtime.go
+++ b/host-go/runtimes/wasmtime/runtime.go
@@ -1,0 +1,139 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package wasmtime
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/lens-vm/lens/host-go/engine/module"
+	"github.com/lens-vm/lens/host-go/engine/pipes"
+
+	"github.com/bytecodealliance/wasmtime-go/v14"
+)
+
+type wRuntime struct {
+	store *wasmtime.Store
+}
+
+var _ module.Runtime = (*wRuntime)(nil)
+
+func New() module.Runtime {
+	engine := wasmtime.NewEngine()
+	store := wasmtime.NewStore(engine)
+
+	return &wRuntime{
+		store: store,
+	}
+}
+
+type wModule struct {
+	rt     *wRuntime
+	module *wasmtime.Module
+}
+
+var _ module.Module = (*wModule)(nil)
+
+func (rt *wRuntime) NewModule(wasmBytes []byte) (module.Module, error) {
+	module, err := wasmtime.NewModule(rt.store.Engine, wasmBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &wModule{
+		rt:     rt,
+		module: module,
+	}, nil
+}
+
+func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) (module.Instance, error) {
+	instance, err := wasmtime.NewInstance(m.rt.store, m.module, []wasmtime.AsExtern{})
+	if err != nil {
+		return module.Instance{}, err
+	}
+
+	mem := instance.GetExport(m.rt.store, "memory")
+	if mem == nil {
+		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "memory"))
+	}
+
+	memory := mem.Memory()
+	if mem == nil {
+		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "memory"))
+	}
+
+	alloc := instance.GetFunc(m.rt.store, "alloc")
+	if alloc == nil {
+		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "alloc"))
+	}
+
+	transform := instance.GetFunc(m.rt.store, functionName)
+	if transform == nil {
+		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", functionName))
+	}
+
+	params := map[string]any{}
+	// Merge the param sets into a single map in case more than
+	// one map is provided.
+	for _, paramSet := range paramSets {
+		for key, value := range paramSet {
+			params[key] = value
+		}
+	}
+
+	if len(params) > 0 {
+		setParam := instance.GetFunc(m.rt.store, "set_param")
+		if setParam == nil {
+			return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "set_param"))
+		}
+
+		sourceBytes, err := json.Marshal(params)
+		if err != nil {
+			return module.Instance{}, err
+		}
+
+		index, err := alloc.Call(m.rt.store, module.TypeIdSize+module.MemSize(len(sourceBytes))+module.LenSize)
+		if err != nil {
+			return module.Instance{}, err
+		}
+
+		err = pipes.WriteItem(module.JSONTypeID, sourceBytes, memory.UnsafeData(m.rt.store)[index.(module.MemSize):])
+		if err != nil {
+			return module.Instance{}, err
+		}
+
+		r, err := setParam.Call(m.rt.store, index)
+		if err != nil {
+			return module.Instance{}, err
+		}
+
+		// The `set_param` wasm function may error, in which case the error needs to be retrieved
+		// from memory using `pipes.GetItem`.
+		_, err = pipes.GetItem(memory.UnsafeData(m.rt.store), r.(module.MemSize))
+		if err != nil {
+			return module.Instance{}, err
+		}
+	}
+
+	return module.Instance{
+		Alloc: func(u module.MemSize) (module.MemSize, error) {
+			r, err := alloc.Call(m.rt.store, u)
+			if err != nil {
+				return 0, err
+			}
+			return r.(module.MemSize), err
+		},
+		Transform: func(u module.MemSize) (module.MemSize, error) {
+			r, err := transform.Call(m.rt.store, u)
+			if err != nil {
+				return 0, err
+			}
+			return r.(module.MemSize), err
+		},
+		GetData: func() []byte { return memory.UnsafeData(m.rt.store) },
+		OwnedBy: instance,
+	}, nil
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #58

## Description

Adds the wasmtime runtime and sets it to default.

Is nice to have in its self, and is probably currently the best runtime for us in most cases - am planning on switching Defra to this (instead of wazero).

Code is pretty much a copy paste of the wasmer runtime with a few small tweaks.  They both follow very similar patterns.

## How has this been tested?

- `make test`
- Defra's `make test:lens`

Specify the platform(s) on which this was tested:
- Debian Linux
- Mac
