### PR TITLE
ci: Add tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
         matrix:
-          os: [ubuntu-latest, macos-latest]
+          os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -37,9 +37,6 @@ jobs:
         with:
           go-version: "1.20"
           check-latest: true
-
-      - if: ${{ matrix.os == 'windows-latest' }}
-        run: choco install mingw --version=12.2.0
 
       - name: Build dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+name: Test Workflow
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - main
+
+jobs:
+  run-tests:
+    name: Run tests job
+
+    strategy:
+        matrix:
+          os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CGO_ENABLED: 1
+
+    steps:
+      - name: Checkout code into the directory
+        uses: actions/checkout@v3
+
+      - name: Setup Go environment explicitly
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.20"
+          check-latest: true
+
+      - if: ${{ matrix.os == 'windows-latest' }}
+        run: choco install mingw --version=12.2.0
+
+      - name: Build dependencies
+        run: |
+          make deps:test-ci
+
+      - name: Run tests
+        run: make test:ci
+

--- a/.github/workflows/validate-title.yml
+++ b/.github/workflows/validate-title.yml
@@ -1,12 +1,6 @@
-# Copyright 2022 Democratized Data Foundation
-#
-# Use of this software is governed by the Business Source License
-# included in the file licenses/BSL.txt.
-#
-# As of the Change Date specified in that file, in accordance with
-# the Business Source License, use of this software will be governed
-# by the Apache License, Version 2.0, included in the file
-# licenses/APL.txt.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 name: Validate Title Workflow
 

--- a/.github/workflows/validate-title.yml
+++ b/.github/workflows/validate-title.yml
@@ -18,7 +18,7 @@ on:
       - reopened
       - synchronize
     branches:
-      - develop
+      - main
 
 jobs:
   validate-title:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,24 @@
+.PHONY: deps\:test-ci
+deps\:test-ci:
+	go install gotest.tools/gotestsum@latest
+	$(MAKE) -C ./host-go build
+	$(MAKE) -C ./tests/modules build
+
+.PHONY: deps\:test
+deps\:test:
+	$(MAKE) -C ./host-go build
+	$(MAKE) -C ./tests/modules build
+
 .PHONY: test
 test:
-	$(MAKE) -C ./host-go test
-	$(MAKE) -C ./tests/integration test
+	$(MAKE) deps:test
+	$(MAKE) --no-print-directory -C ./host-go test:no-deps
+	$(MAKE) --no-print-directory -C ./tests/integration test:no-deps
+
+.PHONY: test\:ci
+test\:ci:
+	$(MAKE) --no-print-directory -C ./host-go test:ci
+	$(MAKE) --no-print-directory -C ./tests/integration test:ci
 
 .PHONY: test\:scripts
 test\:scripts:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ Once you have the listed prerequisites installed, you should be able to build ev
 
 The following tools need to be installed and added to your PATH before you can build the full contents of the repository:
 
-- Cargo/rustc, typically installed via [rustup](https://www.rust-lang.org/tools/install)
+- [rustup](https://www.rust-lang.org/tools/install) and Cargo/rustc, typically installed via rustup.
     - Please pay attention to any prerequisites, for example if on Ubuntu you may need to install the `build-essential` package
-- The rust wasm32-unknown-unknown compiler, installed using `rustup target add wasm32-unknown-unknown`
 - If connection errors are experienced when retrieving rust package dependencies from crates.io, you might need to tweak your `.gitconfig` as per this [comment](https://github.com/rust-lang/cargo/issues/3381#issuecomment-1193730972).
 - `npm`, typically installed via [nvm](https://github.com/nvm-sh/nvm#install--update-script)
 - [Go](https://golang.google.cn/doc/install)

--- a/host-go/Makefile
+++ b/host-go/Makefile
@@ -1,8 +1,28 @@
+.PHONY: deps\:test
+deps\:test:
+	$(MAKE) -C ../tests/modules build
+
 .PHONY: build
 build:
 	(cd cli && go build -o ../build/host-go)
 
-test:
-	$(MAKE) -C ../tests/modules build
+.PHONY: clean
+clean:
 	go clean -testcache
+
+.PHONY: test
+test:
+	@$(MAKE) deps:test
+	@$(MAKE) clean
 	go test ./...
+
+.PHONY: test\:no-deps
+test\:no-deps:
+	@$(MAKE) clean
+	go test ./...
+
+.PHONY: test\:ci
+test\:ci:
+# We do not make the deps here, the ci does that seperately to avoid compiling stuff
+# multiple times etc.
+	gotestsum --format testname ./...

--- a/host-go/Makefile
+++ b/host-go/Makefile
@@ -4,7 +4,7 @@ deps\:test:
 
 .PHONY: build
 build:
-	(cd cli && go build -o ../build/host-go)
+	(cd cli && go build -o ../build/host-go.exe)
 
 .PHONY: clean
 clean:

--- a/host-go/runtimes/wasmer/runtime.go
+++ b/host-go/runtimes/wasmer/runtime.go
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//go:build !windows
+
 package wasmer
 
 import (

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -1,5 +1,25 @@
-test:
+.PHONY: deps\:test
+deps\:test:
 	$(MAKE) -C ../modules build
 	$(MAKE) -C ../../host-go build
+
+.PHONY: clean
+clean:
 	go clean -testcache
+
+.PHONY: test
+test:
+	@$(MAKE) deps:test
+	@$(MAKE) clean
 	go test ./...
+
+.PHONY: test\:no-deps
+test\:no-deps:
+	@$(MAKE) clean
+	go test ./...
+
+.PHONY: test\:ci
+test\:ci:
+# We do not make the deps here, the ci does that seperately to avoid compiling stuff
+# multiple times etc.
+	gotestsum --format testname ./...

--- a/tests/integration/cli/utlis.go
+++ b/tests/integration/cli/utlis.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -33,16 +34,13 @@ type TestCase[TSource any, TResult any] struct {
 
 var hostExecutablePaths = []string{
 	getPathRelativeToProjectRoot(
-		"/host-go/build/host-go",
+		"/host-go/build/host-go.exe",
 	),
 }
 
 func getPathRelativeToProjectRoot(relativePath string) string {
-	filename, err := os.Getwd()
-	if err != nil {
-		panic("failed to get working directory")
-	}
-	root := path.Dir(path.Dir(path.Dir(filename)))
+	_, filename, _, _ := runtime.Caller(0)
+	root := path.Dir(path.Dir(path.Dir(path.Dir(filename))))
 	return path.Join(root, relativePath)
 }
 

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -1,4 +1,10 @@
+.PHONY: deps\:build
+deps\:build:
+	rustup target add wasm32-unknown-unknown
+
+.PHONY: build
 build:
+	$(MAKE) deps:build
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_simple/Cargo.toml"
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_simple2/Cargo.toml"
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_rename/Cargo.toml"


### PR DESCRIPTION
## Relevant issue(s)

Resolves #4

## Description

Adds a tests workflow to run on push.  And organises/expands the make commands. 
