### PR TITLE
feat: WASI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ tests/modules/rust_wasm32_rename/pkg
 sdk-rust/target
 sdk-rust/Cargo.lock
 host-go/build/host-go
+host-go/build/host-go.exe
+.DS_Store

--- a/host-go/config/config.go
+++ b/host-go/config/config.go
@@ -74,7 +74,7 @@ func LoadInto[TSource any, TResult any](
 			continue
 		}
 
-		lensModule, err := engine.NewModule(runtime, moduleCfg.Path)
+		lensModule, err := engine.NewModule(runtime, moduleCfg.Path, moduleCfg.EnableWASI)
 		if err != nil {
 			return nil, err
 		}

--- a/host-go/config/model/lens.go
+++ b/host-go/config/model/lens.go
@@ -27,4 +27,7 @@ type LensModule struct {
 	//
 	// The lens module must expose a `set_param` function if values are provided here.
 	Arguments map[string]any
+
+	// If true WASI imports will be enabled for this module.
+	EnableWASI bool
 }

--- a/host-go/engine/engine.go
+++ b/host-go/engine/engine.go
@@ -46,13 +46,13 @@ func append[TSource any, TResult any](src enumerable.Enumerable[TSource], instan
 // NewModule instantiates a new module from the WAT code at the given path.
 //
 // This is a fairly expensive operation.
-func NewModule(runtime module.Runtime, path string) (module.Module, error) {
+func NewModule(runtime module.Runtime, path string, enableWASI bool) (module.Module, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return runtime.NewModule(content)
+	return runtime.NewModule(content, enableWASI)
 }
 
 func NewInstance(module module.Module, paramSets ...map[string]any) (module.Instance, error) {

--- a/host-go/engine/module/runtime.go
+++ b/host-go/engine/module/runtime.go
@@ -9,5 +9,5 @@ type Runtime interface {
 	// NewModule instantiates a new module from the given WAT code.
 	//
 	// This is a fairly expensive operation.
-	NewModule([]byte) (Module, error)
+	NewModule([]byte, bool) (Module, error)
 }

--- a/host-go/engine/tests/wasm32_pipeline_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_test.go
@@ -18,7 +18,7 @@ import (
 func TestWasm32PipelineFromSourceAsFull(t *testing.T) {
 	runtime := newRuntime()
 
-	module, err := engine.NewModule(runtime, modules.WasmPath1)
+	module, err := engine.NewModule(runtime, modules.WasmPath1, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -59,11 +59,11 @@ func TestWasm32PipelineFromSourceAsFull(t *testing.T) {
 func TestWasm32PipelineFromSourceAsFullToModuleAsFull(t *testing.T) {
 	runtime := newRuntime()
 
-	module1, err := engine.NewModule(runtime, modules.WasmPath1)
+	module1, err := engine.NewModule(runtime, modules.WasmPath1, false)
 	if err != nil {
 		t.Error(err)
 	}
-	module2, err := engine.NewModule(runtime, modules.WasmPath2)
+	module2, err := engine.NewModule(runtime, modules.WasmPath2, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -110,11 +110,11 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFull(t *testing.T) {
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFull(t *testing.T) {
 	runtime := newRuntime()
 
-	module1, err := engine.NewModule(runtime, modules.WasmPath1)
+	module1, err := engine.NewModule(runtime, modules.WasmPath1, false)
 	if err != nil {
 		t.Error(err)
 	}
-	module2, err := engine.NewModule(runtime, modules.WasmPath2)
+	module2, err := engine.NewModule(runtime, modules.WasmPath2, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -162,15 +162,15 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFull(t *testing.T
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToASModuleAsFull(t *testing.T) {
 	runtime := newRuntime()
 
-	module1, err := engine.NewModule(runtime, modules.WasmPath1)
+	module1, err := engine.NewModule(runtime, modules.WasmPath1, false)
 	if err != nil {
 		t.Error(err)
 	}
-	module2, err := engine.NewModule(runtime, modules.WasmPath2)
+	module2, err := engine.NewModule(runtime, modules.WasmPath2, false)
 	if err != nil {
 		t.Error(err)
 	}
-	module3, err := engine.NewModule(runtime, modules.WasmPath3)
+	module3, err := engine.NewModule(runtime, modules.WasmPath3, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -221,11 +221,11 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFullToASModuleAsFull(t *testing
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFullWithSingleAppend(t *testing.T) {
 	runtime := newRuntime()
 
-	module1, err := engine.NewModule(runtime, modules.WasmPath1)
+	module1, err := engine.NewModule(runtime, modules.WasmPath1, false)
 	if err != nil {
 		t.Error(err)
 	}
-	module2, err := engine.NewModule(runtime, modules.WasmPath2)
+	module2, err := engine.NewModule(runtime, modules.WasmPath2, false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/host-go/engine/tests/wasm32_pipeline_with_params_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_with_params_test.go
@@ -18,7 +18,7 @@ import (
 func TestWasm32PipelineWithAddtionalParams(t *testing.T) {
 	runtime := newRuntime()
 
-	module, err := engine.NewModule(runtime, modules.WasmPath4)
+	module, err := engine.NewModule(runtime, modules.WasmPath4, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -65,7 +65,7 @@ func TestWasm32PipelineWithAddtionalParams(t *testing.T) {
 func TestWasm32PipelineMultipleModulesAndWithAddtionalParams(t *testing.T) {
 	runtime := newRuntime()
 
-	module, err := engine.NewModule(runtime, modules.WasmPath4)
+	module, err := engine.NewModule(runtime, modules.WasmPath4, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -127,7 +127,7 @@ func TestWasm32PipelineMultipleModulesAndWithAddtionalParams(t *testing.T) {
 func TestWasm32PipelineWithAddtionalParamsErrors(t *testing.T) {
 	runtime := newRuntime()
 
-	module, err := engine.NewModule(runtime, modules.WasmPath4)
+	module, err := engine.NewModule(runtime, modules.WasmPath4, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -164,7 +164,7 @@ func TestWasm32PipelineWithAddtionalParamsErrors(t *testing.T) {
 func TestWasm32PipelineWithAddtionalParamsErrorsAndNilItem(t *testing.T) {
 	runtime := newRuntime()
 
-	module, err := engine.NewModule(runtime, modules.WasmPath4)
+	module, err := engine.NewModule(runtime, modules.WasmPath4, false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/host-go/runtimes/wazero/runtime.go
+++ b/host-go/runtimes/wazero/runtime.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lens-vm/lens/host-go/engine/module"
 	"github.com/lens-vm/lens/host-go/engine/pipes"
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
 type wRuntime struct {
@@ -35,8 +36,12 @@ type wModule struct {
 
 var _ module.Module = (*wModule)(nil)
 
-func (rt *wRuntime) NewModule(wasmBytes []byte) (module.Module, error) {
+func (rt *wRuntime) NewModule(wasmBytes []byte, wasi bool) (module.Module, error) {
 	ctx := context.TODO()
+	if wasi {
+		wasi_snapshot_preview1.MustInstantiate(ctx, rt.runtime)
+	}
+
 	compiledWasm, err := rt.runtime.CompileModule(ctx, wasmBytes)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Relevant issue(s)

Resolves #68 

## Description

This PR enables WASI imports with a new optional configuration flag.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/validate-conventional-style.sh](tools/configs/validate-conventional-style.sh).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

Manually tested lenses with `wasm32-wasi` target.

If this feature becomes useful I think we should expand the test suite to run with both `unknown` and `wasi` compile targets.

Specify the platform(s) on which this was tested:
- MacOS

