### PR TITLE
feat: Grant host engine control over memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ tests/modules/as_wasm32_simple/package-lock.json
 tests/modules/rust_wasm32_rename/Cargo.lock
 tests/modules/rust_wasm32_rename/target
 tests/modules/rust_wasm32_rename/pkg
+tests/modules/rust_wasm32_copy/Cargo.lock
+tests/modules/rust_wasm32_copy/target
+tests/modules/rust_wasm32_copy/pkg
 sdk-rust/target
 sdk-rust/Cargo.lock
 host-go/build/host-go.exe

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ tests/modules/rust_wasm32_rename/target
 tests/modules/rust_wasm32_rename/pkg
 sdk-rust/target
 sdk-rust/Cargo.lock
-host-go/build/host-go
+host-go/build/host-go.exe

--- a/host-go/engine/module/instance.go
+++ b/host-go/engine/module/instance.go
@@ -10,6 +10,8 @@ type Instance struct {
 	// Alloc allocates the given number of bytes in memory and returns the start index to the allocated block.
 	Alloc func(size MemSize) (MemSize, error)
 
+	Free func(ptr MemSize, size MemSize) error
+
 	// Transform transforms the data stored at the given start index, returning the start index of the result.
 	Transform func(startIndex MemSize) (MemSize, error)
 

--- a/host-go/engine/pipes/fromPipe.go
+++ b/host-go/engine/pipes/fromPipe.go
@@ -76,17 +76,23 @@ func (s *fromPipe[TSource, TResult]) Reset() {
 }
 
 func (s *fromPipe[TSource, TResult]) transport(sourceItem []byte) (module.MemSize, error) {
-	index, err := s.instance.Alloc(module.MemSize(len(sourceItem)))
+	inputSize := module.MemSize(len(sourceItem))
+	inputIndex, err := s.instance.Alloc(inputSize)
 	if err != nil {
 		return 0, err
 	}
 
-	copy(s.instance.GetData()[index:], sourceItem)
+	copy(s.instance.GetData()[inputIndex:], sourceItem)
 
-	index, err = s.instance.Transform(index)
+	returnIndex, err := s.instance.Transform(inputIndex)
 	if err != nil {
 		return 0, err
 	}
 
-	return index, nil
+	err = s.instance.Free(inputIndex, inputSize)
+	if err != nil {
+		return 0, err
+	}
+
+	return returnIndex, nil
 }

--- a/host-go/engine/pipes/fromSource.go
+++ b/host-go/engine/pipes/fromSource.go
@@ -83,20 +83,26 @@ func (s *fromSource[TSource, TResult]) transport(sourceItem TSource) (module.Mem
 		return 0, err
 	}
 
-	index, err := s.instance.Alloc(module.TypeIdSize + module.MemSize(len(sourceBytes)) + module.LenSize)
+	inputSize := module.TypeIdSize + module.MemSize(len(sourceBytes)) + module.LenSize
+	inputIndex, err := s.instance.Alloc(inputSize)
 	if err != nil {
 		return 0, err
 	}
 
-	err = WriteItem(module.JSONTypeID, sourceBytes, s.instance.GetData()[index:])
+	err = WriteItem(module.JSONTypeID, sourceBytes, s.instance.GetData()[inputIndex:])
 	if err != nil {
 		return 0, err
 	}
 
-	index, err = s.instance.Transform(index)
+	returnIndex, err := s.instance.Transform(inputIndex)
 	if err != nil {
 		return 0, err
 	}
 
-	return index, nil
+	err = s.instance.Free(inputIndex, inputSize)
+	if err != nil {
+		return 0, err
+	}
+
+	return returnIndex, nil
 }

--- a/host-go/engine/tests/append_lens_test.go
+++ b/host-go/engine/tests/append_lens_test.go
@@ -45,6 +45,9 @@ func TestAppendLensWithoutWasm(t *testing.T) {
 				var arbitraryIndex module.MemSize = 5
 				return arbitraryIndex, nil
 			},
+			Free: func(ptr, size module.MemSize) error {
+				return nil
+			},
 			Transform: func(startIndex module.MemSize) (module.MemSize, error) {
 				return testModule.nativeTransform(startIndex)
 			},

--- a/host-go/engine/tests/memory_test.go
+++ b/host-go/engine/tests/memory_test.go
@@ -1,0 +1,191 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/host-go/engine"
+	"github.com/lens-vm/lens/host-go/engine/module"
+	"github.com/lens-vm/lens/tests/modules"
+	"github.com/sourcenetwork/immutable/enumerable"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllocAndFreeAreCalledCorrectlyPerItemFromSource(t *testing.T) {
+	sourceSlice := []type1{
+		{
+			Name: "John",
+			Age:  32,
+		},
+		{
+			Name: "Fred",
+			Age:  55,
+		},
+		{
+			Name: "Islam",
+			Age:  35,
+		},
+	}
+	source := enumerable.New(sourceSlice)
+
+	timesAllocCalled := 0
+	timesFreeCalled := 0
+	var lastItemIndex module.MemSize
+	var lastItemSize module.MemSize
+
+	testModule := newNativeModule()
+	results := engine.Append[type1, type2](
+		source,
+		module.Instance{
+			Alloc: func(size module.MemSize) (module.MemSize, error) {
+				lastItemIndex++
+				timesAllocCalled++
+				lastItemSize = size
+				return lastItemIndex, nil
+			},
+			Free: func(ptr, size module.MemSize) error {
+				timesFreeCalled++
+				// Assert that we are freeing the last allocated item
+				assert.Equal(t, ptr, lastItemIndex)
+				assert.Equal(t, size, lastItemSize)
+				return nil
+			},
+			Transform: func(startIndex module.MemSize) (module.MemSize, error) {
+				return testModule.nativeTransform(startIndex)
+			},
+			GetData: func() []byte {
+				return testModule.memory
+			},
+		},
+	)
+
+	hasNext, err := results.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, hasNext)
+
+	hasNext, err = results.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, hasNext)
+
+	hasNext, err = results.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, hasNext)
+
+	hasNext, err = results.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.False(t, hasNext)
+
+	// Assert alloc and free were called once per item
+	assert.Equal(t, len(sourceSlice), timesAllocCalled)
+	assert.Equal(t, len(sourceSlice), timesFreeCalled)
+}
+
+func TestAllocAndFreeAreCalledCorrectlyPerItemFromPipe(t *testing.T) {
+	sourceSlice := []type1{
+		{
+			Name: "John",
+			Age:  32,
+		},
+		{
+			Name: "Fred",
+			Age:  55,
+		},
+		{
+			Name: "Islam",
+			Age:  35,
+		},
+	}
+	source := enumerable.New(sourceSlice)
+
+	runtime := newRuntime()
+
+	wasmModule, err := engine.NewModule(runtime, modules.WasmPath4)
+	if err != nil {
+		t.Error(err)
+	}
+
+	wasmModuleInstance, err := engine.NewInstance(
+		wasmModule,
+		// We rename Name to Name, creating a transform that does nothing, but
+		// will still affect the pipeline used, causing the native module to use
+		// the `fromPipe` pipe, instead of the `fromSource` pipe.
+		map[string]any{
+			"src": "Name",
+			"dst": "Name",
+		},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+
+	timesAllocCalled := 0
+	timesFreeCalled := 0
+	var lastItemIndex module.MemSize
+	var lastItemSize module.MemSize
+
+	testModule := newNativeModule()
+	results := engine.Append[type1, type2](
+		source,
+		wasmModuleInstance,
+		module.Instance{
+			Alloc: func(size module.MemSize) (module.MemSize, error) {
+				lastItemIndex++
+				timesAllocCalled++
+				lastItemSize = size
+				return lastItemIndex, nil
+			},
+			Free: func(ptr, size module.MemSize) error {
+				timesFreeCalled++
+				// Assert that we are freeing the last allocated item
+				assert.Equal(t, ptr, lastItemIndex)
+				assert.Equal(t, size, lastItemSize)
+				return nil
+			},
+			Transform: func(startIndex module.MemSize) (module.MemSize, error) {
+				return testModule.nativeTransform(startIndex)
+			},
+			GetData: func() []byte {
+				return testModule.memory
+			},
+		},
+	)
+
+	hasNext, err := results.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, hasNext)
+
+	hasNext, err = results.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, hasNext)
+
+	hasNext, err = results.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.True(t, hasNext)
+
+	hasNext, err = results.Next()
+	if err != nil {
+		t.Error(err)
+	}
+	assert.False(t, hasNext)
+
+	// Assert alloc and free were called once per item
+	assert.Equal(t, len(sourceSlice), timesAllocCalled)
+	assert.Equal(t, len(sourceSlice), timesFreeCalled)
+}

--- a/host-go/engine/tests/utils.go
+++ b/host-go/engine/tests/utils.go
@@ -5,6 +5,11 @@
 package tests
 
 import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"math"
+
 	"github.com/lens-vm/lens/host-go/engine/module"
 	"github.com/lens-vm/lens/host-go/runtimes/wasmtime"
 )
@@ -21,4 +26,76 @@ type type2 struct {
 
 func newRuntime() module.Runtime {
 	return wasmtime.New()
+}
+
+// nativeModule is a native Go lens module that transforms `type1` items to `type2`.
+//
+// It is used for testing puposes only.
+type nativeModule struct {
+	memory []byte
+}
+
+func newNativeModule() *nativeModule {
+	return &nativeModule{
+		memory: make([]byte, math.MaxUint16),
+	}
+}
+
+func (m *nativeModule) nativeTransform(startIndex module.MemSize) (module.MemSize, error) {
+	typeBuffer := make([]byte, module.TypeIdSize)
+	copy(typeBuffer, m.memory[startIndex:startIndex+module.TypeIdSize])
+	var inputTypeId module.TypeIdType
+	buf := bytes.NewReader(typeBuffer)
+	err := binary.Read(buf, module.TypeIdByteOrder, &inputTypeId)
+	if err != nil {
+		return 0, err
+	}
+
+	lenBuffer := make([]byte, module.LenSize)
+	copy(lenBuffer, m.memory[startIndex+module.TypeIdSize:startIndex+module.TypeIdSize+module.LenSize])
+	var inputLen module.LenType
+	buf = bytes.NewReader(lenBuffer)
+	err = binary.Read(buf, module.LenByteOrder, &inputLen)
+	if err != nil {
+		return 0, err
+	}
+
+	sourceJson := m.memory[startIndex+module.TypeIdSize+module.LenSize : startIndex+module.TypeIdSize+module.MemSize(inputLen)+module.LenSize]
+	sourceItem := &type1{}
+
+	err = json.Unmarshal([]byte(sourceJson), sourceItem)
+	if err != nil {
+		return 0, err
+	}
+
+	resultItem := type2{
+		FullName: sourceItem.Name,
+		Age:      sourceItem.Age,
+	}
+
+	returnBytes, err := json.Marshal(resultItem)
+	if err != nil {
+		return 0, err
+	}
+
+	typeWriter := bytes.NewBuffer([]byte{})
+	err = binary.Write(typeWriter, module.TypeIdByteOrder, int8(1))
+	if err != nil {
+		return 0, err
+	}
+
+	returnLen := module.LenType(len(returnBytes))
+	lenWriter := bytes.NewBuffer([]byte{})
+	err = binary.Write(lenWriter, module.LenByteOrder, returnLen)
+	if err != nil {
+		return 0, err
+	}
+
+	arbitraryReturnIndex := math.MaxUint16 / 2
+	dst := m.memory[arbitraryReturnIndex:]
+	copy(dst, typeWriter.Bytes())
+	copy(dst[module.TypeIdSize:], lenWriter.Bytes())
+	copy(dst[module.TypeIdSize+module.LenSize:], returnBytes)
+
+	return module.MemSize(arbitraryReturnIndex), nil
 }

--- a/host-go/runtimes/wasmer/runtime.go
+++ b/host-go/runtimes/wasmer/runtime.go
@@ -63,6 +63,11 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 		return module.Instance{}, err
 	}
 
+	free, err := instance.Exports.GetRawFunction("free")
+	if err != nil {
+		return module.Instance{}, err
+	}
+
 	transform, err := instance.Exports.GetRawFunction(functionName)
 	if err != nil {
 		return module.Instance{}, err
@@ -118,6 +123,10 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 				return 0, err
 			}
 			return r.(module.MemSize), err
+		},
+		Free: func(ptr, size module.MemSize) error {
+			_, err := free.Call(ptr, size)
+			return err
 		},
 		Transform: func(u module.MemSize) (module.MemSize, error) {
 			r, err := transform.Call(u)

--- a/host-go/runtimes/wasmtime/runtime.go
+++ b/host-go/runtimes/wasmtime/runtime.go
@@ -70,6 +70,11 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "alloc"))
 	}
 
+	free := instance.GetFunc(m.rt.store, "free")
+	if free == nil {
+		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "free"))
+	}
+
 	transform := instance.GetFunc(m.rt.store, functionName)
 	if transform == nil {
 		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", functionName))
@@ -125,6 +130,10 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 				return 0, err
 			}
 			return r.(module.MemSize), err
+		},
+		Free: func(ptr, size module.MemSize) error {
+			_, err := free.Call(m.rt.store, ptr, size)
+			return err
 		},
 		Transform: func(u module.MemSize) (module.MemSize, error) {
 			r, err := transform.Call(m.rt.store, u)

--- a/host-go/runtimes/wazero/runtime.go
+++ b/host-go/runtimes/wazero/runtime.go
@@ -62,6 +62,11 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "alloc"))
 	}
 
+	free := instance.ExportedFunction("free")
+	if alloc == nil {
+		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "free"))
+	}
+
 	transform := instance.ExportedFunction(functionName)
 	if transform == nil {
 		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", functionName))
@@ -119,6 +124,10 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 				return 0, err
 			}
 			return module.MemSize(r[0]), nil
+		},
+		Free: func(ptr, size module.MemSize) error {
+			_, err := free.Call(ctx, uint64(ptr), uint64(size))
+			return err
 		},
 		Transform: func(u module.MemSize) (module.MemSize, error) {
 			r, err := transform.Call(ctx, uint64(u))

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lens_sdk"
-version = "0.1.0"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/tests/integration/cli/simple_test.go
+++ b/tests/integration/cli/simple_test.go
@@ -21,7 +21,7 @@ func TestSimple(t *testing.T) {
 		Age      int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Input, Output]{
 			LensFile: `
@@ -70,7 +70,7 @@ func TestSimpleWithNoModules(t *testing.T) {
 		Age  int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Input, Input]{
 			LensFile: `
@@ -120,7 +120,7 @@ func TestSimpleWithEmptyItem(t *testing.T) {
 		Age      int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Input, Output]{
 			LensFile: `
@@ -168,7 +168,7 @@ func TestSimpleWithNilItem(t *testing.T) {
 		Age      int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[*Input, *Output]{
 			LensFile: `

--- a/tests/integration/cli/utlis.go
+++ b/tests/integration/cli/utlis.go
@@ -44,7 +44,7 @@ func getPathRelativeToProjectRoot(relativePath string) string {
 	return path.Join(root, relativePath)
 }
 
-func executeTest[TSource any, TResult any](t *testing.T, testCase TestCase[TSource, TResult]) {
+func ExecuteTest[TSource any, TResult any](t *testing.T, testCase TestCase[TSource, TResult]) {
 	tempDir := t.TempDir()
 	lensFilePath := path.Join(tempDir, "lensFile.json")
 	err := os.WriteFile(lensFilePath, []byte(testCase.LensFile), 0700)

--- a/tests/integration/cli/with_inverse_modules_test.go
+++ b/tests/integration/cli/with_inverse_modules_test.go
@@ -16,7 +16,7 @@ func TestInverseWithModules(t *testing.T) {
 		Age      int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Value, Value]{
 			LensFile: `

--- a/tests/integration/cli/with_inverse_test.go
+++ b/tests/integration/cli/with_inverse_test.go
@@ -16,7 +16,7 @@ func TestInverse(t *testing.T) {
 		Age      int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Value, Value]{
 			LensFile: `
@@ -66,7 +66,7 @@ func TestInverseErrorsGivenNoInverseAvailable(t *testing.T) {
 		Age  int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Value, Value]{
 			LensFile: `

--- a/tests/integration/cli/with_modules_params_test.go
+++ b/tests/integration/cli/with_modules_params_test.go
@@ -21,7 +21,7 @@ func TestWithModulesWithParams(t *testing.T) {
 		Age        int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Input, Output]{
 			LensFile: `

--- a/tests/integration/cli/with_modules_test.go
+++ b/tests/integration/cli/with_modules_test.go
@@ -21,7 +21,7 @@ func TestSimpleWithModules(t *testing.T) {
 		Age      int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Input, Output]{
 			LensFile: `
@@ -74,7 +74,7 @@ func TestSimpleWithModulesRepeated(t *testing.T) {
 		Age      int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Value, Value]{
 			LensFile: `

--- a/tests/integration/cli/with_params_test.go
+++ b/tests/integration/cli/with_params_test.go
@@ -21,7 +21,7 @@ func TestWithParams(t *testing.T) {
 		Age        int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Input, Output]{
 			LensFile: `
@@ -79,7 +79,7 @@ func TestWithParamsReturnsErrorGivenBadParam(t *testing.T) {
 		Age        int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Input, Output]{
 			LensFile: `
@@ -124,7 +124,7 @@ func TestWithParamsReturnsErrorGivenNilParam(t *testing.T) {
 		Age        int
 	}
 
-	executeTest(
+	ExecuteTest(
 		t,
 		TestCase[Input, Output]{
 			LensFile: `

--- a/tests/integration/memory/memory_test.go
+++ b/tests/integration/memory/memory_test.go
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package memory
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lens-vm/lens/host-go/engine"
+	"github.com/lens-vm/lens/host-go/engine/module"
+	"github.com/lens-vm/lens/host-go/runtimes/wasmtime"
+	"github.com/lens-vm/lens/host-go/runtimes/wazero"
+	"github.com/lens-vm/lens/tests/modules"
+)
+
+// The maximum allocation that can be made in one alloc call across all tested wasm langs.
+//
+// Language specific limits are as follows:
+// - Rust: math.MaxInt32
+// - AssemblyScript: math.MaxInt32 / 4
+const maxAllocationSize int32 = math.MaxInt32 / 4
+
+var runtimeConstructors = []func() module.Runtime{
+	wasmtime.New,
+	wazero.New,
+	// wasmer doesn't work/compile on windows, so we append it to the set via not_windows_runtimes_test.go
+	//wasmer.New,
+}
+
+// Note: Testing that lens modules do not leak memory when passing items to/from via the cli would be slow,
+// for now we make do with testing that alloc and free do work, in all test modules and all runtimes.
+// Indiviual host engines will need to write their own tests to ensure that alloc and free are called
+// correctly.
+
+func TestAllocErrorsWhenOutOfMemory(t *testing.T) {
+	for _, modulePath := range modules.AllModules {
+		for _, runtimeConstructor := range runtimeConstructors {
+			runtime := runtimeConstructor()
+
+			module, err := engine.NewModule(runtime, modulePath)
+			require.NoError(t, err)
+
+			instance, err := module.NewInstance("transform")
+			require.NoError(t, err)
+
+			indexes := make([]int32, 7)
+			for i := 1; i <= 7; i++ {
+				index, err := instance.Alloc(maxAllocationSize)
+				require.NoError(t, err)
+
+				indexes = append(indexes, index)
+			}
+			// The 8th call should fail, as we run out of 32bit memory
+			_, err = instance.Alloc(maxAllocationSize)
+			require.Error(t, err)
+
+			for _, index := range indexes {
+				// Free the allocations at the end of the runtime-loop, or
+				// we'll have out of memory problems on smaller machines
+				_ = instance.Free(index, maxAllocationSize)
+			}
+		}
+	}
+}
+
+func TestAllocThenFreePastMemoryLimitDoesNotError(t *testing.T) {
+	for _, modulePath := range modules.AllModules {
+		for _, runtimeConstructor := range runtimeConstructors {
+			runtime := runtimeConstructor()
+
+			module, err := engine.NewModule(runtime, modulePath)
+			require.NoError(t, err)
+
+			instance, err := module.NewInstance("transform")
+			require.NoError(t, err)
+
+			// The 8th call would fail if free did not work, as we would
+			// run out of 32bit memory.  Assuming free cannot partially
+			// succeed - the testing for which would be too expensive
+			// to bother right now.
+			for i := 1; i <= 8; i++ {
+				index, err := instance.Alloc(maxAllocationSize)
+				require.NoError(t, err)
+				err = instance.Free(index, maxAllocationSize)
+				require.NoError(t, err)
+			}
+		}
+	}
+}

--- a/tests/integration/memory/not_windows_runtimes_test.go
+++ b/tests/integration/memory/not_windows_runtimes_test.go
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !windows
+
+package memory
+
+import "github.com/lens-vm/lens/host-go/runtimes/wasmer"
+
+func init() {
+	// Wasmer doesn't work on windows so we add it to the set this way
+	runtimeConstructors = append(runtimeConstructors, wasmer.New)
+}

--- a/tests/modules/as_wasm32_simple/assembly/index.ts
+++ b/tests/modules/as_wasm32_simple/assembly/index.ts
@@ -20,10 +20,11 @@ function abort(
 const JSON_TYPE_ID: i8 = 1;
 
 export function alloc(size: usize): usize {
-    let buf = new ArrayBuffer(i32(size));
-    let ptr = changetype<usize>(buf);
-    store<ArrayBuffer>(ptr, buf);
-    return ptr;
+    return heap.alloc(size);
+}
+
+export function free(ptr: usize, size: usize): void {
+    heap.free(ptr)
 }
 
 export function transform(ptr: usize): usize {

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -40,6 +40,11 @@ pub extern fn alloc(size: usize) -> *mut u8 {
 }
 
 #[no_mangle]
+pub extern fn free(ptr: *mut u8, size: usize) {
+    lens_sdk::free(ptr, size)
+}
+
+#[no_mangle]
 pub extern fn set_param(ptr: *mut u8) -> *mut u8 {
     match try_set_param(ptr) {
         Ok(_) => lens_sdk::nil_ptr(),

--- a/tests/modules/rust_wasm32_simple/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple/src/lib.rs
@@ -27,6 +27,11 @@ pub extern fn alloc(size: usize) -> *mut u8 {
 }
 
 #[no_mangle]
+pub extern fn free(ptr: *mut u8, size: usize) {
+    lens_sdk::free(ptr, size)
+}
+
+#[no_mangle]
 pub extern fn transform(ptr: *mut u8) -> *mut u8 {
     match try_transform(ptr) {
         Ok(o) => match o {

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -19,6 +19,11 @@ pub extern fn alloc(size: usize) -> *mut u8 {
 }
 
 #[no_mangle]
+pub extern fn free(ptr: *mut u8, size: usize) {
+    lens_sdk::free(ptr, size)
+}
+
+#[no_mangle]
 pub extern fn transform(ptr: *mut u8) -> *mut u8 {
     match try_transform(ptr) {
         Ok(o) => match o {

--- a/tests/modules/utils.go
+++ b/tests/modules/utils.go
@@ -31,6 +31,13 @@ var WasmPath4 string = getPathRelativeToProjectRoot(
 	"/tests/modules/rust_wasm32_rename/target/wasm32-unknown-unknown/debug/rust_wasm32_rename.wasm",
 )
 
+var AllModules = []string{
+	WasmPath1,
+	WasmPath2,
+	WasmPath3,
+	WasmPath4,
+}
+
 func getPathRelativeToProjectRoot(relativePath string) string {
 	_, filename, _, _ := runtime.Caller(0)
 	root := path.Dir(path.Dir(path.Dir(filename)))


### PR DESCRIPTION
## Relevant issue(s)

Resolves #62

## Description

Adds a new `free` function to the wasm interface.  

This gives the host engine control over when allocated memory is freed - right now this means memory is allocated immediately prior to passing items to the wasm module, and then freed when receiving the result.
