### PR TITLE
docs: Add details to Rust SDK cargo.toml file

### DIFF
--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "lens_sdk"
+description = "An SDK for writing bi-directional, wasm based, LensVM transformations in Rust"
 version = "0.5.0"
 edition = "2021"
+readme = "../README.md"
+repository = "https://github.com/lens-vm/lens"
+license-file = "../LICENSE"
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
## Relevant issue(s)

Resolves #74

## Description

Adds details to Rust SDK cargo.toml file.

These need to be added before we can publish.