### PR TITLE
chore: Bump to wasmtime v21

### DIFF
--- a/host-go/go.mod
+++ b/host-go/go.mod
@@ -3,7 +3,7 @@ module github.com/lens-vm/lens/host-go
 go 1.18
 
 require (
-	github.com/bytecodealliance/wasmtime-go/v15 v15.0.0
+	github.com/bytecodealliance/wasmtime-go/v21 v21.0.0
 	github.com/lens-vm/lens/tests/modules v0.0.0-20230720125121-328ae81f5744
 	github.com/sourcenetwork/immutable v0.2.0
 	github.com/stretchr/testify v1.8.1

--- a/host-go/go.sum
+++ b/host-go/go.sum
@@ -1,5 +1,5 @@
-github.com/bytecodealliance/wasmtime-go/v15 v15.0.0 h1:4R2MpSPPbtSxqdsOTvsMn1pnwdEhzbDGMao6LUUSLv4=
-github.com/bytecodealliance/wasmtime-go/v15 v15.0.0/go.mod h1:m6vB/SsM+pnJkVHmO1wzHYUeYtciltTKuxuvkR8pYcY=
+github.com/bytecodealliance/wasmtime-go/v21 v21.0.0 h1:d2m3R7TpNpOGuIi2PTC9w2nUY/A2IJinHOZTL76jyhg=
+github.com/bytecodealliance/wasmtime-go/v21 v21.0.0/go.mod h1:o/HNPe7TdXkqbrkmU9YgHBFXU9OIF1FVPlqhZwC1tyk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/host-go/runtimes/wasmtime/runtime.go
+++ b/host-go/runtimes/wasmtime/runtime.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lens-vm/lens/host-go/engine/module"
 	"github.com/lens-vm/lens/host-go/engine/pipes"
 
-	"github.com/bytecodealliance/wasmtime-go/v15"
+	"github.com/bytecodealliance/wasmtime-go/v21"
 )
 
 type wRuntime struct {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #81

## Description

Updates wasmtime version from v15 to v21.

No wasmtime-go code has changed, although the underlying rust implementation has.  Not looking for anything in particular, but we shouldn't let it get too out of date and presumably improvements have been made. The wasmtime-go windows build still seems to be disabled.