### PR TITLE
chore: Bump Rust SDK version to 0.6.0

### DIFF
--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lens_sdk"
 description = "An SDK for writing bi-directional, wasm based, LensVM transformations in Rust"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 readme = "../README.md"
 repository = "https://github.com/lens-vm/lens"


### PR DESCRIPTION
## Description

Bumps the Rust SDK version to 0.6.0.

I want to release a 0.6.0 version, bumping the wasmtime version, and the rust SDK should stay in sync I think even though there are no changes.I want to release a 0.6.0 version, bumping the wasmtime version, and the rust SDK should stay in sync I think even though there are no changes.