### PR TITLE
fix: Handle inputs of moderate size and up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ tests/modules/rust_wasm32_filter/pkg
 tests/modules/rust_wasm32_normalize/Cargo.lock
 tests/modules/rust_wasm32_normalize/target
 tests/modules/rust_wasm32_normalize/pkg
+tests/modules/rust_wasm32_memory/Cargo.lock
+tests/modules/rust_wasm32_memory/target
+tests/modules/rust_wasm32_memory/pkg
 sdk-rust/target
 sdk-rust/Cargo.lock
 host-go/build/host-go.exe

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lens_sdk"
 description = "An SDK for writing bi-directional, wasm based, LensVM transformations in Rust"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 readme = "../README.md"
 repository = "https://github.com/lens-vm/lens"

--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["lib"]
 
 [dependencies]
 serde = "1.0"
-serde_json = "1.0.87"
-byteorder = "1.4.3"
+serde_json = "1.0"
+byteorder = "1.4"

--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -172,15 +172,15 @@ pub fn try_from_mem<TOutput: for<'a> Deserialize<'a>>(ptr: *mut u8) -> Result<St
 
     let type_id: i8  = type_rdr.read_i8()?;
     if type_id == NIL_TYPE_ID {
-        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        free_transport_buffer(ptr)?;
         return Ok(StreamOption::None)
     }
     if type_id == EOS_TYPE_ID {
-        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        free_transport_buffer(ptr)?;
         return Ok(StreamOption::EndOfStream)
     }
     if type_id < 0 {
-        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        free_transport_buffer(ptr)?;
         return Result::from(error::LensError::InputErrorUnsupportedError)
     }
 

--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -137,7 +137,7 @@ pub fn free_transport_buffer(ptr: *mut u8) -> Result<()> {
 
     let len: usize = len_rdr.read_u32::<LittleEndian>()?.try_into()?;
 
-    free(ptr, len);
+    free(ptr, mem::size_of::<i8>()+mem::size_of::<u32>()+len);
 
     Ok(())
 }

--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -236,7 +236,8 @@ pub fn try_to_mem(type_id: i8, message: &[u8]) -> Result<*mut u8> {
         }
     };
 
-    let result = wtr.into_inner().clone().as_mut_ptr();
+    let mut buffer = wtr.into_inner().clone();
+    let result = buffer.as_mut_ptr();
     Ok(result)
 }
 

--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -82,7 +82,7 @@ pub fn free(ptr: *mut u8, size: usize) {
         Vec::from_raw_parts(ptr, size, size)
     };
     let buf = ManuallyDrop::new(buf);
-    mem::drop(ManuallyDrop::into_inner(buf));
+    ManuallyDrop::into_inner(buf);
 }
 
 /// Manually drop the memory occupied by a transport buffer at the given location.
@@ -116,15 +116,15 @@ pub fn free_transport_buffer(ptr: *mut u8) -> Result<()> {
 
     let type_id: i8  = type_rdr.read_i8()?;
     if type_id == NIL_TYPE_ID {
-        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        ManuallyDrop::into_inner(type_rdr);
         return Ok(())
     }
     if type_id == EOS_TYPE_ID {
-        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        ManuallyDrop::into_inner(type_rdr);
         return Ok(())
     }
     if type_id < 0 {
-        mem::drop(ManuallyDrop::into_inner(type_rdr));
+        ManuallyDrop::into_inner(type_rdr);
         return Ok(())
     }
 

--- a/tests/integration/cli/with_mem_test.go
+++ b/tests/integration/cli/with_mem_test.go
@@ -1,0 +1,47 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/lens-vm/lens/tests/modules"
+)
+
+// Rust is very aggressive in cleaning up memory, and we had a bug where lenses would fail if the input
+// was particularly large, and/or the transform copied the input too many times.
+func TestWithMem(t *testing.T) {
+	type Value struct {
+		Name string
+		Type string `json:"__type"`
+		// Inline arrays seem to be particularly problematic, I guess it is due to some lifetime stuff
+		// in the serde library.
+		Array []string
+	}
+
+	executeTest(
+		t,
+		TestCase[Value, Value]{
+			LensFile: `
+			{
+				"lenses": [
+					{
+						"path": "` + modules.WasmPath_Memory + `"
+					}
+				]
+			}`,
+			Input: []Value{
+				{
+					Name:  "John",
+					Type:  "passsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+					Array: []string{},
+				},
+			},
+			ExpectedOutput: []Value{
+				{
+					Name:  "John",
+					Type:  "passsssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+					Array: []string{},
+				},
+			},
+		},
+	)
+}

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -11,4 +11,5 @@ build:
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_counter/Cargo.toml"
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_filter/Cargo.toml"
 	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_normalize/Cargo.toml"
+	cargo build --target wasm32-unknown-unknown --manifest-path "./rust_wasm32_memory/Cargo.toml"
 	(cd "./as_wasm32_simple/" && npm install && npm run asbuild:debug)

--- a/tests/modules/rust_wasm32_counter/src/lib.rs
+++ b/tests/modules/rust_wasm32_counter/src/lib.rs
@@ -10,7 +10,7 @@ extern "C" {
     fn next() -> *mut u8;
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Value {
     #[serde(rename = "Id")]
 	pub id: usize,

--- a/tests/modules/rust_wasm32_filter/src/lib.rs
+++ b/tests/modules/rust_wasm32_filter/src/lib.rs
@@ -8,7 +8,7 @@ extern "C" {
     fn next() -> *mut u8;
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Value {
     #[serde(rename = "Name")]
     pub name: String,

--- a/tests/modules/rust_wasm32_memory/Cargo.toml
+++ b/tests/modules/rust_wasm32_memory/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust-wasm32-memory"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+lens_sdk = { path = "../../../sdk-rust" }

--- a/tests/modules/rust_wasm32_memory/src/lib.rs
+++ b/tests/modules/rust_wasm32_memory/src/lib.rs
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::error::Error;
+use serde::{Deserialize, Serialize};
+use lens_sdk::StreamOption;
+use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
+
+#[link(wasm_import_module = "lens")]
+extern "C" {
+    fn next() -> *mut u8;
+}
+
+#[no_mangle]
+pub extern "C" fn alloc(size: usize) -> *mut u8 {
+    lens_sdk::alloc(size)
+}
+
+#[no_mangle]
+pub extern "C" fn transform() -> *mut u8 {
+    match try_transform() {
+        Ok(o) => match o {
+            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
+            None => lens_sdk::nil_ptr(),
+            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
+        },
+        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Input {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename= "__type")]
+	pub __type: String,
+    #[serde(rename = "Array")]
+	pub array: Vec<String>,
+}
+
+fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
+    let ptr = unsafe { next() };
+    let mut input = match lens_sdk::try_from_mem::<Input>(ptr)? {
+        Some(v) => v,
+        // Implementations of `transform` are free to handle nil however they like. In this
+        // implementation we chose to return nil given a nil input.
+        None => return Ok(None),
+        EndOfStream => return Ok(EndOfStream)
+    };
+
+    for _ in 1..1000 {
+        // Copy the input a bunch of times to make sure that the memory is not cleaned up
+        // before we are finished with it.
+        input = input.clone();
+    }
+
+    let result_json = serde_json::to_vec(&input.clone())?;
+    lens_sdk::free_transport_buffer(ptr)?;
+    Ok(Some(result_json))
+}

--- a/tests/modules/rust_wasm32_normalize/src/lib.rs
+++ b/tests/modules/rust_wasm32_normalize/src/lib.rs
@@ -11,7 +11,7 @@ extern "C" {
     fn next() -> *mut u8;
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Book {
     #[serde(rename = "Name")]
     pub name: String,

--- a/tests/modules/rust_wasm32_simple/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple/src/lib.rs
@@ -12,7 +12,7 @@ extern "C" {
     fn next() -> *mut u8;
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct Input {
     #[serde(rename(deserialize = "Name"))]
     pub name: String,

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -12,7 +12,7 @@ extern "C" {
     fn next() -> *mut u8;
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Value {
     #[serde(rename = "FullName")]
     pub name: String,

--- a/tests/modules/utils.go
+++ b/tests/modules/utils.go
@@ -46,6 +46,12 @@ var WasmPath7 string = getPathRelativeToProjectRoot(
 	"/tests/modules/rust_wasm32_normalize/target/wasm32-unknown-unknown/debug/rust_wasm32_normalize.wasm",
 )
 
+// WasmPath_Memory contains a wasm32 rust lens that copies the input item multiple times before returning it
+// in order to check for memory related bugs.
+var WasmPath_Memory string = getPathRelativeToProjectRoot(
+	"/tests/modules/rust_wasm32_memory/target/wasm32-unknown-unknown/debug/rust_wasm32_memory.wasm",
+)
+
 func getPathRelativeToProjectRoot(relativePath string) string {
 	_, filename, _, _ := runtime.Caller(0)
 	root := path.Dir(path.Dir(path.Dir(filename)))


### PR DESCRIPTION
## Relevant issue(s)

Resolves #90
Resolves #89

## Description

Handles inputs of moderate size and up by ensuring that the input byte array is fully cloned before parsing it as json.

I think something serde was doing when given inner arrays caused bits of memory to be disposed of before we had finished with them - the failing test either return an empty object, or error out with a corrupted memory block.

I recommend reviewing commit by commit.