### PR TITLE
feat: Remove need for Rust lens files to call free

### DIFF
--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -161,7 +161,7 @@ pub fn free_transport_buffer(ptr: *mut u8) -> Result<()> {
 ///
 /// This function will return an [Error](error/enum.Error.html) if the data at the given location is not in the expected
 /// format.
-pub fn try_from_mem<TOutput: for<'a> Deserialize<'a> + Clone>(ptr: *mut u8) -> Result<StreamOption<TOutput>> {
+pub fn try_from_mem<TOutput: for<'a> Deserialize<'a>>(ptr: *mut u8) -> Result<StreamOption<TOutput>> {
     let type_vec: Vec<u8> = unsafe {
         Vec::from_raw_parts(ptr, mem::size_of::<i8>(), mem::size_of::<i8>())
     };

--- a/tests/modules/rust_wasm32_counter/src/lib.rs
+++ b/tests/modules/rust_wasm32_counter/src/lib.rs
@@ -55,6 +55,5 @@ fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
     };
 
     let result_json = serde_json::to_vec(&result)?;
-    lens_sdk::free_transport_buffer(ptr)?;
     Ok(Some(result_json))
 }

--- a/tests/modules/rust_wasm32_counter/src/lib.rs
+++ b/tests/modules/rust_wasm32_counter/src/lib.rs
@@ -10,7 +10,7 @@ extern "C" {
     fn next() -> *mut u8;
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub struct Value {
     #[serde(rename = "Id")]
 	pub id: usize,

--- a/tests/modules/rust_wasm32_filter/src/lib.rs
+++ b/tests/modules/rust_wasm32_filter/src/lib.rs
@@ -8,7 +8,7 @@ extern "C" {
     fn next() -> *mut u8;
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub struct Value {
     #[serde(rename = "Name")]
     pub name: String,

--- a/tests/modules/rust_wasm32_filter/src/lib.rs
+++ b/tests/modules/rust_wasm32_filter/src/lib.rs
@@ -48,6 +48,5 @@ fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
             let result_json = serde_json::to_vec(&input)?;
             return Ok(Some(result_json))
         }
-        lens_sdk::free_transport_buffer(ptr)?;
     }
 }

--- a/tests/modules/rust_wasm32_memory/src/lib.rs
+++ b/tests/modules/rust_wasm32_memory/src/lib.rs
@@ -56,6 +56,5 @@ fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
     }
 
     let result_json = serde_json::to_vec(&input.clone())?;
-    lens_sdk::free_transport_buffer(ptr)?;
     Ok(Some(result_json))
 }

--- a/tests/modules/rust_wasm32_normalize/src/lib.rs
+++ b/tests/modules/rust_wasm32_normalize/src/lib.rs
@@ -11,7 +11,7 @@ extern "C" {
     fn next() -> *mut u8;
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub struct Book {
     #[serde(rename = "Name")]
     pub name: String,
@@ -19,7 +19,7 @@ pub struct Book {
 	pub page_numbers: Vec<i32>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub struct Page {
     #[serde(rename = "BookName")]
     pub book_name: String,

--- a/tests/modules/rust_wasm32_normalize/src/lib.rs
+++ b/tests/modules/rust_wasm32_normalize/src/lib.rs
@@ -66,7 +66,6 @@ fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
             };
             pending_pages.push_back(page);
         }
-        lens_sdk::free_transport_buffer(ptr)?;
     }
 
     if pending_pages.len() > 0 {

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -98,6 +98,5 @@ fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
     input.insert(params.dst, value);
     
     let result_json = serde_json::to_vec(&input)?;
-    lens_sdk::free_transport_buffer(ptr)?;
     Ok(Some(result_json))
 }

--- a/tests/modules/rust_wasm32_simple/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple/src/lib.rs
@@ -61,6 +61,5 @@ fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
     };
     
     let result_json = serde_json::to_vec(&result)?;
-    lens_sdk::free_transport_buffer(ptr)?;
     Ok(Some(result_json))
 }

--- a/tests/modules/rust_wasm32_simple/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple/src/lib.rs
@@ -12,7 +12,7 @@ extern "C" {
     fn next() -> *mut u8;
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize)]
 pub struct Input {
     #[serde(rename(deserialize = "Name"))]
     pub name: String,

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -84,6 +84,5 @@ fn try_inverse() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
     };
 
     let result_json = serde_json::to_vec(&result)?;
-    lens_sdk::free_transport_buffer(ptr)?;
     Ok(Some(result_json))
 }

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -12,7 +12,7 @@ extern "C" {
     fn next() -> *mut u8;
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize)]
 pub struct Value {
     #[serde(rename = "FullName")]
     pub name: String,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #92 

## Description

Removes the need for Rust lens files to call free_transport_buffer - this is now included in the `try_from_mem` func.

Also removes the `Clone` constraint from `try_from_mem`, which was enabled by the moving of `free`.

Looking at the fix I am unsure why my other attempts to fix this failed - it looks very very similar to a whole bunch of stuff I tried.

I've tested this using the Defra Lens tests as well.