### PR TITLE
chore: Bump rust crates to 2024 edition

### DIFF
--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lens_sdk"
 description = "An SDK for writing bi-directional, wasm based, LensVM transformations in Rust"
 version = "0.7.0"
-edition = "2021"
+edition = "2024"
 readme = "../README.md"
 repository = "https://github.com/lens-vm/lens"
 license-file = "../LICENSE"

--- a/tests/modules/rust_wasm32_counter/Cargo.toml
+++ b/tests/modules/rust_wasm32_counter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-counter"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/modules/rust_wasm32_counter/src/lib.rs
+++ b/tests/modules/rust_wasm32_counter/src/lib.rs
@@ -21,12 +21,12 @@ pub struct Value {
 static COUNTER: Lazy<RelaxedCounter> = Lazy::new(|| RelaxedCounter::new(0));
 
 #[unsafe(no_mangle)]
-pub extern fn alloc(size: usize) -> *mut u8 {
+pub extern "C" fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
 #[unsafe(no_mangle)]
-pub extern fn transform() -> *mut u8 {
+pub extern "C" fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {
             Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),

--- a/tests/modules/rust_wasm32_counter/src/lib.rs
+++ b/tests/modules/rust_wasm32_counter/src/lib.rs
@@ -6,7 +6,7 @@ use lens_sdk::StreamOption;
 use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
 #[link(wasm_import_module = "lens")]
-extern "C" {
+unsafe extern "C" {
     fn next() -> *mut u8;
 }
 
@@ -20,12 +20,12 @@ pub struct Value {
 
 static COUNTER: Lazy<RelaxedCounter> = Lazy::new(|| RelaxedCounter::new(0));
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {

--- a/tests/modules/rust_wasm32_filter/Cargo.toml
+++ b/tests/modules/rust_wasm32_filter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-filter"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/modules/rust_wasm32_filter/src/lib.rs
+++ b/tests/modules/rust_wasm32_filter/src/lib.rs
@@ -17,12 +17,12 @@ pub struct Value {
 }
 
 #[unsafe(no_mangle)]
-pub extern fn alloc(size: usize) -> *mut u8 {
+pub extern "C" fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
 #[unsafe(no_mangle)]
-pub extern fn transform() -> *mut u8 {
+pub extern "C" fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {
             Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),

--- a/tests/modules/rust_wasm32_filter/src/lib.rs
+++ b/tests/modules/rust_wasm32_filter/src/lib.rs
@@ -4,7 +4,7 @@ use lens_sdk::StreamOption;
 use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
 #[link(wasm_import_module = "lens")]
-extern "C" {
+unsafe extern "C" {
     fn next() -> *mut u8;
 }
 
@@ -16,12 +16,12 @@ pub struct Value {
 	pub type_name: String,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {

--- a/tests/modules/rust_wasm32_memory/Cargo.toml
+++ b/tests/modules/rust_wasm32_memory/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-memory"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/modules/rust_wasm32_memory/src/lib.rs
+++ b/tests/modules/rust_wasm32_memory/src/lib.rs
@@ -8,16 +8,16 @@ use lens_sdk::StreamOption;
 use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
 #[link(wasm_import_module = "lens")]
-extern "C" {
+unsafe extern "C" {
     fn next() -> *mut u8;
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {

--- a/tests/modules/rust_wasm32_normalize/Cargo.toml
+++ b/tests/modules/rust_wasm32_normalize/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-normalize"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/modules/rust_wasm32_normalize/src/lib.rs
+++ b/tests/modules/rust_wasm32_normalize/src/lib.rs
@@ -30,12 +30,12 @@ pub struct Page {
 static PENDING_PAGES: RwLock<Lazy<VecDeque<Page>>> = RwLock::new(Lazy::new(|| VecDeque::new()));
 
 #[unsafe(no_mangle)]
-pub extern fn alloc(size: usize) -> *mut u8 {
+pub extern "C" fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
 #[unsafe(no_mangle)]
-pub extern fn transform() -> *mut u8 {
+pub extern "C" fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {
             Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json.clone()),

--- a/tests/modules/rust_wasm32_normalize/src/lib.rs
+++ b/tests/modules/rust_wasm32_normalize/src/lib.rs
@@ -7,7 +7,7 @@ use lens_sdk::StreamOption;
 use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
 #[link(wasm_import_module = "lens")]
-extern "C" {
+unsafe extern "C" {
     fn next() -> *mut u8;
 }
 
@@ -29,12 +29,12 @@ pub struct Page {
 
 static PENDING_PAGES: RwLock<Lazy<VecDeque<Page>>> = RwLock::new(Lazy::new(|| VecDeque::new()));
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {

--- a/tests/modules/rust_wasm32_rename/Cargo.toml
+++ b/tests/modules/rust_wasm32_rename/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-rename"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -11,7 +11,7 @@ use lens_sdk::StreamOption;
 use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
 #[link(wasm_import_module = "lens")]
-extern "C" {
+unsafe extern "C" {
     fn next() -> *mut u8;
 }
 
@@ -41,12 +41,12 @@ pub struct Parameters {
 
 static PARAMETERS: RwLock<StreamOption<Parameters>> = RwLock::new(None);
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn set_param(ptr: *mut u8) -> *mut u8 {
     match try_set_param(ptr) {
         Ok(_) => lens_sdk::nil_ptr(),
@@ -63,7 +63,7 @@ fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -42,12 +42,12 @@ pub struct Parameters {
 static PARAMETERS: RwLock<StreamOption<Parameters>> = RwLock::new(None);
 
 #[unsafe(no_mangle)]
-pub extern fn alloc(size: usize) -> *mut u8 {
+pub extern "C" fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
 #[unsafe(no_mangle)]
-pub extern fn set_param(ptr: *mut u8) -> *mut u8 {
+pub extern "C" fn set_param(ptr: *mut u8) -> *mut u8 {
     match try_set_param(ptr) {
         Ok(_) => lens_sdk::nil_ptr(),
         Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
@@ -64,7 +64,7 @@ fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
 }
 
 #[unsafe(no_mangle)]
-pub extern fn transform() -> *mut u8 {
+pub extern "C" fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {
             Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),

--- a/tests/modules/rust_wasm32_simple/Cargo.toml
+++ b/tests/modules/rust_wasm32_simple/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-simple"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/modules/rust_wasm32_simple/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple/src/lib.rs
@@ -8,7 +8,7 @@ use lens_sdk::StreamOption;
 use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
 #[link(wasm_import_module = "lens")]
-extern "C" {
+unsafe extern "C" {
     fn next() -> *mut u8;
 }
 
@@ -28,12 +28,12 @@ pub struct Output {
 	pub age: u64,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {

--- a/tests/modules/rust_wasm32_simple/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple/src/lib.rs
@@ -29,12 +29,12 @@ pub struct Output {
 }
 
 #[unsafe(no_mangle)]
-pub extern fn alloc(size: usize) -> *mut u8 {
+pub extern "C" fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
 #[unsafe(no_mangle)]
-pub extern fn transform() -> *mut u8 {
+pub extern "C" fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {
             Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),

--- a/tests/modules/rust_wasm32_simple2/Cargo.toml
+++ b/tests/modules/rust_wasm32_simple2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm32-simple2"
 version = "0.1.0"
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -8,7 +8,7 @@ use lens_sdk::StreamOption;
 use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
 #[link(wasm_import_module = "lens")]
-extern "C" {
+unsafe extern "C" {
     fn next() -> *mut u8;
 }
 
@@ -20,12 +20,12 @@ pub struct Value {
 	pub age: i64,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {
@@ -56,7 +56,7 @@ fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
     Ok(Some(result_json))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern fn inverse() -> *mut u8 {
     match try_inverse() {
         Ok(o) => match o {

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -21,12 +21,12 @@ pub struct Value {
 }
 
 #[unsafe(no_mangle)]
-pub extern fn alloc(size: usize) -> *mut u8 {
+pub extern "C" fn alloc(size: usize) -> *mut u8 {
     lens_sdk::alloc(size)
 }
 
 #[unsafe(no_mangle)]
-pub extern fn transform() -> *mut u8 {
+pub extern "C" fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {
             Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
@@ -57,7 +57,7 @@ fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
 }
 
 #[unsafe(no_mangle)]
-pub extern fn inverse() -> *mut u8 {
+pub extern "C" fn inverse() -> *mut u8 {
     match try_inverse() {
         Ok(o) => match o {
             Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),


### PR DESCRIPTION
## Relevant issue(s)

Resolves #96

## Description

Bumps the rust crates to the 2024 edition.

They were getting a bit out of date.  Warnings fixed.

Please do not review the first commit here.  Explanations in the commit messages.