### PR TITLE
feat: Add boilerplate handling macros

### DIFF
--- a/sdk-rust/src/error.rs
+++ b/sdk-rust/src/error.rs
@@ -66,6 +66,7 @@ impl From<LensError> for Error {
 pub enum LensError {
     InputErrorUnsupportedError,
     FailedToWriteErrorToMemError,
+    ParametersNotSetError,
 }
 
 impl error::Error for LensError { }
@@ -75,6 +76,7 @@ impl fmt::Display for LensError {
         match &*self {
             LensError::InputErrorUnsupportedError => f.write_str("Using errors as inputs is currently unsupported."),
             LensError::FailedToWriteErrorToMemError => f.write_str("An error occured when attempting to write an error to memory."),
+            LensError::ParametersNotSetError => f.write_str("Parameters have not been set."),
         }
     }
 }

--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -457,6 +457,29 @@ macro_rules! define_transform {
     };
 }
 
+/// Define the optional `inverse` function for this Lens.
+///
+/// This macro wraps the provided `try_inverse` function, providing the boilerplate required to handle input items
+/// sent across the WASM boundary from the Lens engine. The resultant function is responsible for inversing transforms
+/// on input items pulled in by [next()](macro.define_next.html) and yields a pointer to the serialized result.
+///
+/// It assumes that a `next()` function exists within the calling scope.
+#[macro_export]
+macro_rules! define_inverse {
+    ($try_inverse:ident) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn inverse() -> *mut u8 {
+            $crate::next(|| -> *mut u8 { unsafe { next() } }, $try_inverse)
+        }
+    };
+    ($next:ident, $try_inverse:ident) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn inverse() -> *mut u8 {
+            $crate::next($next(), $try_inverse)
+        }
+    };
+}
+
 /// Define the optional `set_param` function for this Lens.
 ///
 /// `set_param` is used to recieve static parameters from the Lens engine. If parameters are provided to the Lens

--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -420,3 +420,16 @@ macro_rules! define_alloc {
         }
     };
 }
+
+/// Define the mandatory `next` function for this Lens.
+///
+/// It is responsible for pulling the pointer to the next input item from the Lens engine.
+#[macro_export]
+macro_rules! define_next {
+    () => {
+        #[link(wasm_import_module = "lens")]
+        unsafe extern "C" {
+            fn next() -> *mut u8;
+        }
+    };
+}

--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -407,3 +407,16 @@ impl<TInput> Iterator for InputIterator<'_, TInput>
         }
     }
 }
+
+/// Define the mandatory `alloc` function for this Lens.
+///
+/// It is responsible for allocating memory for input items and will be called by the Lens engine.
+#[macro_export]
+macro_rules! define_alloc {
+    () => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn alloc(size: usize) -> *mut u8 {
+            $crate::alloc(size)
+        }
+    };
+}

--- a/sdk-rust/src/lib.rs
+++ b/sdk-rust/src/lib.rs
@@ -433,3 +433,26 @@ macro_rules! define_next {
         }
     };
 }
+
+/// Define the mandatory `transform` function for this Lens.
+///
+/// This macro wraps the provided `try_transform` function, providing the boilerplate required to handle input items
+/// sent across the WASM boundary from the Lens engine. The resultant function is responsible for transforming
+/// input items pulled in by [next()](macro.define_next.html) and yields a pointer to the serialized result.
+///
+/// It assumes that a `next()` function exists within the calling scope.
+#[macro_export]
+macro_rules! define_transform {
+    ($try_transform:ident) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn transform() -> *mut u8 {
+            $crate::next(|| -> *mut u8 { unsafe { next() } }, $try_transform)
+        }
+    };
+    ($next:ident, $try_transform:ident) => {
+        #[unsafe(no_mangle)]
+        pub extern "C" fn transform() -> *mut u8 {
+            $crate::next($next(), $try_transform)
+        }
+    };
+}

--- a/tests/modules/rust_wasm32_filter/src/lib.rs
+++ b/tests/modules/rust_wasm32_filter/src/lib.rs
@@ -5,6 +5,7 @@ use lens_sdk::StreamOption;
 
 lens_sdk::define_alloc!();
 lens_sdk::define_next!();
+lens_sdk::define_transform!(try_transform);
 
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Debug))]
@@ -13,11 +14,6 @@ pub struct Value {
     pub name: String,
     #[serde(rename = "__type")]
 	pub type_name: String,
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn transform() -> *mut u8 {
-    lens_sdk::next(|| -> *mut u8 { unsafe { next() } }, try_transform)
 }
 
 fn try_transform(

--- a/tests/modules/rust_wasm32_filter/src/lib.rs
+++ b/tests/modules/rust_wasm32_filter/src/lib.rs
@@ -3,6 +3,8 @@ use std::iter::Iterator;
 use serde::{Serialize, Deserialize};
 use lens_sdk::StreamOption;
 
+lens_sdk::define_alloc!();
+
 #[link(wasm_import_module = "lens")]
 unsafe extern "C" {
     fn next() -> *mut u8;
@@ -15,11 +17,6 @@ pub struct Value {
     pub name: String,
     #[serde(rename = "__type")]
 	pub type_name: String,
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn alloc(size: usize) -> *mut u8 {
-    lens_sdk::alloc(size)
 }
 
 #[unsafe(no_mangle)]

--- a/tests/modules/rust_wasm32_filter/src/lib.rs
+++ b/tests/modules/rust_wasm32_filter/src/lib.rs
@@ -3,9 +3,7 @@ use std::iter::Iterator;
 use serde::{Serialize, Deserialize};
 use lens_sdk::StreamOption;
 
-lens_sdk::define_alloc!();
-lens_sdk::define_next!();
-lens_sdk::define_transform!(try_transform);
+lens_sdk::define!(try_transform);
 
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Debug))]

--- a/tests/modules/rust_wasm32_filter/src/lib.rs
+++ b/tests/modules/rust_wasm32_filter/src/lib.rs
@@ -4,11 +4,7 @@ use serde::{Serialize, Deserialize};
 use lens_sdk::StreamOption;
 
 lens_sdk::define_alloc!();
-
-#[link(wasm_import_module = "lens")]
-unsafe extern "C" {
-    fn next() -> *mut u8;
-}
+lens_sdk::define_next!();
 
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Debug))]

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -8,7 +8,6 @@ use std::error::Error;
 use std::{fmt, error};
 use serde::Deserialize;
 use lens_sdk::StreamOption;
-use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
 #[link(wasm_import_module = "lens")]
 unsafe extern "C" {
@@ -39,7 +38,7 @@ pub struct Parameters {
     pub dst: String,
 }
 
-static PARAMETERS: RwLock<StreamOption<Parameters>> = RwLock::new(None);
+static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
 
 #[unsafe(no_mangle)]
 pub extern "C" fn alloc(size: usize) -> *mut u8 {
@@ -67,9 +66,9 @@ fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
 pub extern "C" fn transform() -> *mut u8 {
     match try_transform() {
         Ok(o) => match o {
-            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            None => lens_sdk::nil_ptr(),
-            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
+            StreamOption::Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
+            StreamOption::None => lens_sdk::nil_ptr(),
+            StreamOption::EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
         },
         Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
     }
@@ -78,11 +77,11 @@ pub extern "C" fn transform() -> *mut u8 {
 fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
     let ptr = unsafe { next() };
     let mut input = match unsafe { lens_sdk::try_from_mem::<HashMap<String, serde_json::Value>>(ptr)? } {
-        Some(v) => v,
+        StreamOption::Some(v) => v,
         // Implementations of `transform` are free to handle nil however they like. In this
         // implementation we chose to return nil given a nil input.
-        None => return Ok(None),
-        EndOfStream => return Ok(EndOfStream)
+        StreamOption::None => return Ok(StreamOption::None),
+        StreamOption::EndOfStream => return Ok(StreamOption::EndOfStream)
     };
 
     let params = PARAMETERS.read()?
@@ -98,5 +97,5 @@ fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
     input.insert(params.dst, value);
     
     let result_json = serde_json::to_vec(&input)?;
-    Ok(Some(result_json))
+    Ok(StreamOption::Some(result_json))
 }

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -10,10 +10,7 @@ use serde::Deserialize;
 use lens_sdk::StreamOption;
 use lens_sdk::error::LensError;
 
-lens_sdk::define_alloc!();
-lens_sdk::define_next!();
-lens_sdk::define_transform!(try_transform);
-lens_sdk::define_set_param!(PARAMETERS: Parameters);
+lens_sdk::define!(PARAMETERS: Parameters, try_transform);
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 enum ModuleError {

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -13,6 +13,7 @@ use lens_sdk::error::LensError;
 lens_sdk::define_alloc!();
 lens_sdk::define_next!();
 lens_sdk::define_transform!(try_transform);
+lens_sdk::define_set_param!(PARAMETERS: Parameters);
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 enum ModuleError {
@@ -37,23 +38,6 @@ pub struct Parameters {
 }
 
 static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
-
-#[unsafe(no_mangle)]
-pub extern "C" fn set_param(ptr: *mut u8) -> *mut u8 {
-    match try_set_param(ptr) {
-        Ok(_) => lens_sdk::nil_ptr(),
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
-    let parameter =  unsafe { lens_sdk::try_from_mem::<Parameters>(ptr)? }
-        .ok_or(LensError::ParametersNotSetError)?;
-
-    let mut dst = PARAMETERS.write()?;
-    *dst = Some(parameter);
-    Ok(())
-}
 
 fn try_transform(
     iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, serde_json::Value>>>>,

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -10,6 +10,8 @@ use serde::Deserialize;
 use lens_sdk::StreamOption;
 use lens_sdk::error::LensError;
 
+lens_sdk::define_alloc!();
+
 #[link(wasm_import_module = "lens")]
 unsafe extern "C" {
     fn next() -> *mut u8;
@@ -38,11 +40,6 @@ pub struct Parameters {
 }
 
 static PARAMETERS: RwLock<Option<Parameters>> = RwLock::new(None);
-
-#[unsafe(no_mangle)]
-pub extern "C" fn alloc(size: usize) -> *mut u8 {
-    lens_sdk::alloc(size)
-}
 
 #[unsafe(no_mangle)]
 pub extern "C" fn set_param(ptr: *mut u8) -> *mut u8 {

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -12,6 +12,7 @@ use lens_sdk::error::LensError;
 
 lens_sdk::define_alloc!();
 lens_sdk::define_next!();
+lens_sdk::define_transform!(try_transform);
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 enum ModuleError {
@@ -54,40 +55,28 @@ fn try_set_param(ptr: *mut u8) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn transform() -> *mut u8 {
-    match try_transform() {
-        Ok(o) => match o {
-            StreamOption::Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            StreamOption::None => lens_sdk::nil_ptr(),
-            StreamOption::EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
-        },
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
-
-fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
-    let ptr = unsafe { next() };
-    let mut input = match unsafe { lens_sdk::try_from_mem::<HashMap<String, serde_json::Value>>(ptr)? } {
-        StreamOption::Some(v) => v,
-        // Implementations of `transform` are free to handle nil however they like. In this
-        // implementation we chose to return nil given a nil input.
-        StreamOption::None => return Ok(StreamOption::None),
-        StreamOption::EndOfStream => return Ok(StreamOption::EndOfStream)
-    };
-
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, serde_json::Value>>>>,
+) -> Result<StreamOption<HashMap<String, serde_json::Value>>, Box<dyn Error>> {
     let params = PARAMETERS.read()?
         .clone()
-        .ok_or(LensError::ParametersNotSetError)?
-        .clone();
+        .ok_or(LensError::ParametersNotSetError)?;
 
-    let value = input.get_mut(&params.src)
-        .ok_or(ModuleError::PropertyNotFoundError{requested: params.src.clone()})?
-        .clone();
-    
-    input.remove(&params.src);
-    input.insert(params.dst, value);
-    
-    let result_json = serde_json::to_vec(&input)?;
-    Ok(StreamOption::Some(result_json))
+    for item in iter {
+        let mut input = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
+
+        let value = input.get_mut(&params.src)
+            .ok_or(ModuleError::PropertyNotFoundError{requested: params.src.clone()})?
+            .clone();
+
+        input.remove(&params.src);
+        input.insert(params.dst.clone(), value);
+
+        return Ok(StreamOption::Some(input))
+    }
+
+    Ok(StreamOption::EndOfStream)
 }

--- a/tests/modules/rust_wasm32_rename/src/lib.rs
+++ b/tests/modules/rust_wasm32_rename/src/lib.rs
@@ -11,11 +11,7 @@ use lens_sdk::StreamOption;
 use lens_sdk::error::LensError;
 
 lens_sdk::define_alloc!();
-
-#[link(wasm_import_module = "lens")]
-unsafe extern "C" {
-    fn next() -> *mut u8;
-}
+lens_sdk::define_next!();
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 enum ModuleError {

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -7,6 +7,8 @@ use serde::{Serialize, Deserialize};
 use lens_sdk::StreamOption;
 use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
+lens_sdk::define_alloc!();
+
 #[link(wasm_import_module = "lens")]
 unsafe extern "C" {
     fn next() -> *mut u8;
@@ -18,11 +20,6 @@ pub struct Value {
     pub name: String,
     #[serde(rename = "Age")]
 	pub age: i64,
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn alloc(size: usize) -> *mut u8 {
-    lens_sdk::alloc(size)
 }
 
 #[unsafe(no_mangle)]

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -8,11 +8,7 @@ use lens_sdk::StreamOption;
 use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
 lens_sdk::define_alloc!();
-
-#[link(wasm_import_module = "lens")]
-unsafe extern "C" {
-    fn next() -> *mut u8;
-}
+lens_sdk::define_next!();
 
 #[derive(Serialize, Deserialize)]
 pub struct Value {

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -5,10 +5,10 @@
 use std::error::Error;
 use serde::{Serialize, Deserialize};
 use lens_sdk::StreamOption;
-use lens_sdk::option::StreamOption::{Some, None, EndOfStream};
 
 lens_sdk::define_alloc!();
 lens_sdk::define_next!();
+lens_sdk::define_transform!(try_transform);
 
 #[derive(Serialize, Deserialize)]
 pub struct Value {
@@ -18,44 +18,33 @@ pub struct Value {
 	pub age: i64,
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn transform() -> *mut u8 {
-    match try_transform() {
-        Ok(o) => match o {
-            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            None => lens_sdk::nil_ptr(),
-            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
-        },
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
-    }
-}
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<Value>>>,
+) -> Result<StreamOption<Value>, Box<dyn Error>> {
+    for item in iter {
+        let input = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
 
-fn try_transform() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
-    let ptr = unsafe { next() };
-    let input = match unsafe { lens_sdk::try_from_mem::<Value>(ptr)? } {
-        Some(v) => v,
-        // Implementations of `transform` are free to handle nil however they like. In this
-        // implementation we chose to return nil given a nil input.
-        None => return Ok(None),
-        EndOfStream => return Ok(EndOfStream),
-    };
-    
-    let result = Value {
-        name: input.name,
-        age: input.age + 1,
-    };
-    
-    let result_json = serde_json::to_vec(&result)?;
-    Ok(Some(result_json))
+        let result = Value {
+            name: input.name,
+            age: input.age + 1,
+        };
+
+        return Ok(StreamOption::Some(result))
+    }
+
+    Ok(StreamOption::EndOfStream)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn inverse() -> *mut u8 {
     match try_inverse() {
         Ok(o) => match o {
-            Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            None => lens_sdk::nil_ptr(),
-            EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
+            StreamOption::Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
+            StreamOption::None => lens_sdk::nil_ptr(),
+            StreamOption::EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
         },
         Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
     }
@@ -64,11 +53,11 @@ pub extern "C" fn inverse() -> *mut u8 {
 fn try_inverse() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
     let ptr = unsafe { next() };
     let input = match unsafe { lens_sdk::try_from_mem::<Value>(ptr)? } {
-        Some(v) => v,
+        StreamOption::Some(v) => v,
         // Implementations of `transform` are free to handle nil however they like. In this
         // implementation we chose to return nil given a nil input.
-        None => return Ok(None),
-        EndOfStream => return Ok(EndOfStream),
+        StreamOption::None => return Ok(StreamOption::None),
+        StreamOption::EndOfStream => return Ok(StreamOption::EndOfStream),
     };
 
     let result = Value {
@@ -77,5 +66,5 @@ fn try_inverse() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
     };
 
     let result_json = serde_json::to_vec(&result)?;
-    Ok(Some(result_json))
+    Ok(StreamOption::Some(result_json))
 }

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -6,10 +6,7 @@ use std::error::Error;
 use serde::{Serialize, Deserialize};
 use lens_sdk::StreamOption;
 
-lens_sdk::define_alloc!();
-lens_sdk::define_next!();
-lens_sdk::define_transform!(try_transform);
-lens_sdk::define_inverse!(try_inverse);
+lens_sdk::define!(try_transform, try_inverse);
 
 #[derive(Serialize, Deserialize)]
 pub struct Value {

--- a/tests/modules/rust_wasm32_simple2/src/lib.rs
+++ b/tests/modules/rust_wasm32_simple2/src/lib.rs
@@ -9,6 +9,7 @@ use lens_sdk::StreamOption;
 lens_sdk::define_alloc!();
 lens_sdk::define_next!();
 lens_sdk::define_transform!(try_transform);
+lens_sdk::define_inverse!(try_inverse);
 
 #[derive(Serialize, Deserialize)]
 pub struct Value {
@@ -38,33 +39,22 @@ fn try_transform(
     Ok(StreamOption::EndOfStream)
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn inverse() -> *mut u8 {
-    match try_inverse() {
-        Ok(o) => match o {
-            StreamOption::Some(result_json) => lens_sdk::to_mem(lens_sdk::JSON_TYPE_ID, &result_json),
-            StreamOption::None => lens_sdk::nil_ptr(),
-            StreamOption::EndOfStream => lens_sdk::to_mem(lens_sdk::EOS_TYPE_ID, &[]),
-        },
-        Err(e) => lens_sdk::to_mem(lens_sdk::ERROR_TYPE_ID, &e.to_string().as_bytes())
+fn try_inverse(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<Value>>>,
+) -> Result<StreamOption<Value>, Box<dyn Error>> {
+    for item in iter {
+        let input = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
+
+        let result = Value {
+            name: input.name,
+            age: input.age - 1,
+        };
+
+        return Ok(StreamOption::Some(result))
     }
-}
 
-fn try_inverse() -> Result<StreamOption<Vec<u8>>, Box<dyn Error>> {
-    let ptr = unsafe { next() };
-    let input = match unsafe { lens_sdk::try_from_mem::<Value>(ptr)? } {
-        StreamOption::Some(v) => v,
-        // Implementations of `transform` are free to handle nil however they like. In this
-        // implementation we chose to return nil given a nil input.
-        StreamOption::None => return Ok(StreamOption::None),
-        StreamOption::EndOfStream => return Ok(StreamOption::EndOfStream),
-    };
-
-    let result = Value {
-        name: input.name,
-        age: input.age - 1,
-    };
-
-    let result_json = serde_json::to_vec(&result)?;
-    Ok(StreamOption::Some(result_json))
+    Ok(StreamOption::EndOfStream)
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #18
Resolves #19

## Description

Adds a handful of boilerplate handling macros.  The are designed to be usable in isolation as well as via `define!`  in order to allow some bits to be manually crafted by Lens authors should they wish to make adjustments.

> Rust macros are a way of writing code that writes other code, which is known as metaprogramming

https://doc.rust-lang.org/book/ch20-05-macros.html 
https://doc.rust-lang.org/reference/macros-by-example.html

It would be possible to expand this work further in the future using procedural macros, potentially handling some of this via attributes, but I dont think the cost-benefit of that stacks up right now, writing them is quite a bit more involved than these regular macros.