### PR TITLE
chore: Bump rust sdk to 0.8.0

### DIFF
--- a/sdk-rust/Cargo.toml
+++ b/sdk-rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lens_sdk"
 description = "An SDK for writing bi-directional, wasm based, LensVM transformations in Rust"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 readme = "../README.md"
 repository = "https://github.com/lens-vm/lens"


### PR DESCRIPTION
## Relevant issue(s)

Resolves #102

## Description

Bumps the rust sdk to 0.8.0.

I'll release once this PR and https://github.com/lens-vm/lens/pull/101 are merged.
