### PR TITLE
feat: Disable wasmtime for windows

### DIFF
--- a/host-go/engine/module/runtime.go
+++ b/host-go/engine/module/runtime.go
@@ -6,6 +6,11 @@ package module
 
 // Runtime represents the runtime hosting lens instances.
 type Runtime interface {
+	// Name returns the type-name of this runtime.
+	//
+	// It is useful if a direct reference to certain runtime packages is undesirable.
+	Name() string
+
 	// NewModule instantiates a new module from the given WAT code.
 	//
 	// This is a fairly expensive operation.

--- a/host-go/engine/tests/wasm32_pipeline_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_test.go
@@ -109,6 +109,10 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFull(t *testing.T) {
 
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFull(t *testing.T) {
 	runtime := newRuntime()
+	if runtime.Name() == "wazero" {
+		// This is due to https://github.com/sourcenetwork/lens/issues/71
+		t.Skipf("runtime does not support instance reuse")
+	}
 
 	module1, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {
@@ -220,6 +224,10 @@ func TestWasm32PipelineFromSourceAsFullToModuleAsFullToASModuleAsFull(t *testing
 
 func TestWasm32PipelineFromSourceAsFullToModuleAsFullToModuleAsFullWithSingleAppend(t *testing.T) {
 	runtime := newRuntime()
+	if runtime.Name() == "wazero" {
+		// This is due to https://github.com/sourcenetwork/lens/issues/71
+		t.Skipf("runtime does not support instance reuse")
+	}
 
 	module1, err := engine.NewModule(runtime, modules.WasmPath1)
 	if err != nil {

--- a/host-go/engine/tests/wasm32_pipeline_with_state_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_with_state_test.go
@@ -19,6 +19,10 @@ func TestWasm32PipelineWithSharedState(t *testing.T) {
 		Name string
 	}
 	runtime := newRuntime()
+	if runtime.Name() == "wazero" {
+		// This is due to https://github.com/sourcenetwork/lens/issues/71
+		t.Skipf("runtime does not support instance reuse")
+	}
 
 	module, err := engine.NewModule(runtime, modules.WasmPath5)
 	if err != nil {

--- a/host-go/runtimes/js/runtime.go
+++ b/host-go/runtimes/js/runtime.go
@@ -19,6 +19,8 @@ import (
 	"github.com/sourcenetwork/lens/host-go/engine/pipes"
 )
 
+const Name string = "js"
+
 type wRuntime struct {
 	webAssembly js.Value
 }
@@ -31,6 +33,10 @@ func New() module.Runtime {
 	// https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface
 	webAssembly := js.Global().Get("WebAssembly")
 	return &wRuntime{webAssembly}
+}
+
+func (rt *wRuntime) Name() string {
+	return Name
 }
 
 func (rt *wRuntime) NewModule(wasmBytes []byte) (module.Module, error) {

--- a/host-go/runtimes/runtimes.go
+++ b/host-go/runtimes/runtimes.go
@@ -1,4 +1,4 @@
-//go:build !js && !cshared
+//go:build !windows && !js && !cshared
 
 package runtimes
 

--- a/host-go/runtimes/runtimes_windows.go
+++ b/host-go/runtimes/runtimes_windows.go
@@ -1,0 +1,12 @@
+//go:build windows && !js && !cshared
+
+package runtimes
+
+import (
+	"github.com/sourcenetwork/lens/host-go/engine/module"
+	"github.com/sourcenetwork/lens/host-go/runtimes/wazero"
+)
+
+func Default() module.Runtime {
+	return wazero.New()
+}

--- a/host-go/runtimes/wasmer/runtime.go
+++ b/host-go/runtimes/wasmer/runtime.go
@@ -18,6 +18,8 @@ import (
 	"github.com/wasmerio/wasmer-go/wasmer"
 )
 
+const Name string = "wasmer"
+
 type wRuntime struct {
 	store *wasmer.Store
 }
@@ -38,6 +40,10 @@ type wModule struct {
 }
 
 var _ module.Module = (*wModule)(nil)
+
+func (rt *wRuntime) Name() string {
+	return Name
+}
 
 func (rt *wRuntime) NewModule(wasmBytes []byte) (module.Module, error) {
 	module, err := wasmer.NewModule(rt.store, wasmBytes)

--- a/host-go/runtimes/wasmtime/runtime.go
+++ b/host-go/runtimes/wasmtime/runtime.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//go:build !js
+//go:build !windows && !js
 
 package wasmtime
 
@@ -18,6 +18,8 @@ import (
 
 	"github.com/bytecodealliance/wasmtime-go/v35"
 )
+
+const Name string = "wasmtime"
 
 type wRuntime struct {
 	store *wasmtime.Store
@@ -40,6 +42,10 @@ type wModule struct {
 }
 
 var _ module.Module = (*wModule)(nil)
+
+func (rt *wRuntime) Name() string {
+	return Name
+}
 
 func (rt *wRuntime) NewModule(wasmBytes []byte) (module.Module, error) {
 	module, err := wasmtime.NewModule(rt.store.Engine, wasmBytes)

--- a/host-go/runtimes/wazero/runtime.go
+++ b/host-go/runtimes/wazero/runtime.go
@@ -20,6 +20,8 @@ import (
 	"github.com/tetratelabs/wazero"
 )
 
+const Name string = "wazero"
+
 type wRuntime struct {
 	compilationCache wazero.CompilationCache
 }
@@ -42,6 +44,10 @@ type wModule struct {
 }
 
 var _ module.Module = (*wModule)(nil)
+
+func (rt *wRuntime) Name() string {
+	return Name
+}
 
 func (rt *wRuntime) NewModule(wasmBytes []byte) (module.Module, error) {
 	return &wModule{


### PR DESCRIPTION
## Relevant issue(s)

Resolves #120

## Description

Disables the wasmtime runtime for windows, as it is too unreliable when embedding at the moment.  

Wazero is still available, and is default, on windows.  Performance concerns more likely to be secondary on a windows machine.

Broken out from https://github.com/sourcenetwork/lens/pull/119 where the tests that fail are visible.
