### PR TITLE
fix: Close iter on error

### DIFF
--- a/host-go/store/store.go
+++ b/host-go/store/store.go
@@ -144,7 +144,7 @@ func list(ctx context.Context, txn *txn) (map[cid.Cid]model.Lens, error) {
 
 		config, err := loadLensModel(ctx, txn.linkSystem, configCID)
 		if err != nil {
-			return nil, err
+			return nil, errors.Join(err, iter.Close())
 		}
 		results[configCID] = config
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #131

## Description

Closes the iter in store.list on error.

Sorry about the bother, I missed this error-close earlier.  Caught by Defra, Lens tests can be added later.