### PR TITLE
feat: Add JS support to node package

### DIFF
--- a/host-go/Makefile
+++ b/host-go/Makefile
@@ -21,6 +21,8 @@ test\:no-deps:
 	@$(MAKE) clean
 	go test ./...
 
+JS_TEST_FLAGS=-exec="$$(go env GOROOT)/lib/wasm/go_js_wasm_exec" -shuffle=on -timeout 10m
+
 .PHONY: test\:ci
 test\:ci:
 # We do not make the deps here, the ci does that seperately to avoid compiling stuff
@@ -29,4 +31,4 @@ test\:ci:
 
 .PHONY: test\:js
 test\:js:
-	GOOS=js GOARCH=wasm gotestsum --format testname -- -exec wasmbrowsertest ./...
+	GOOS=js GOARCH=wasm go test ./... $(JS_TEST_FLAGS)

--- a/host-go/node/node.go
+++ b/host-go/node/node.go
@@ -10,23 +10,14 @@ import (
 
 	badgerds "github.com/dgraph-io/badger/v4"
 	"github.com/sourcenetwork/corekv"
-	sourceP2P "github.com/sourcenetwork/go-p2p"
 
 	"github.com/sourcenetwork/corekv/badger"
 	"github.com/sourcenetwork/immutable"
-	"github.com/sourcenetwork/lens/host-go/p2p"
 	"github.com/sourcenetwork/lens/host-go/runtimes"
 	"github.com/sourcenetwork/lens/host-go/store"
 )
 
 type closer = func() error
-
-type Node struct {
-	onClose []closer
-	Options Options
-	Store   store.TxnStore
-	P2P     immutable.Option[*p2p.P2P]
-}
 
 func New(ctx context.Context, opts ...Option) (*Node, error) {
 	var o Options
@@ -77,39 +68,9 @@ func New(ctx context.Context, opts ...Option) (*Node, error) {
 		o.IndexstoreNamespace = immutable.Some("i")
 	}
 
-	var p2pSys immutable.Option[*p2p.P2P]
-	if !o.DisableP2P {
-		var host p2p.Host
-		if o.P2P.HasValue() {
-			host = o.P2P.Value()
-		} else {
-			p2pOptions := append(
-				o.P2POptions,
-				sourceP2P.WithBlockstoreNamespace(o.BlockstoreNamespace.Value()),
-				sourceP2P.WithRootstore(o.Rootstore.Value()),
-			)
-
-			if o.BlockstoreChunkSize.HasValue() {
-				p2pOptions = append(p2pOptions, sourceP2P.WithBlockstoreChunkSize(o.BlockstoreChunkSize.Value()))
-			}
-
-			var err error
-			host, err = sourceP2P.NewPeer(
-				ctx,
-				p2pOptions...,
-			)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		p2pSys = immutable.Some(p2p.New(host, o.Rootstore.Value(), o.IndexstoreNamespace.Value()))
-	}
-
-	node := &Node{
-		onClose: onClose,
-		Options: o,
-		Store: store.New(
+	node, err := createNode(
+		ctx,
+		store.New(
 			o.TxnSource.Value(),
 			o.PoolSize.Value(),
 			o.Runtime.Value(),
@@ -117,12 +78,16 @@ func New(ctx context.Context, opts ...Option) (*Node, error) {
 			o.BlockstoreChunkSize,
 			o.IndexstoreNamespace.Value(),
 		),
-		P2P: p2pSys,
+		o,
+		onClose,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	// Reload on create, if the store is persisted, this will read any Lenses already in the store and
 	// add them to the repository.
-	err := node.Store.Reload(ctx)
+	err = node.Store.Reload(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/host-go/node/node_p2p.go
+++ b/host-go/node/node_p2p.go
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !js
+
+package node
+
+import (
+	"context"
+
+	"github.com/sourcenetwork/corekv"
+	sourceP2P "github.com/sourcenetwork/go-p2p"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/lens/host-go/engine/module"
+	"github.com/sourcenetwork/lens/host-go/p2p"
+	"github.com/sourcenetwork/lens/host-go/store"
+)
+
+type Options struct {
+	Path                immutable.Option[string]
+	Rootstore           immutable.Option[corekv.TxnReaderWriter]
+	TxnSource           immutable.Option[store.TxnSource]
+	PoolSize            immutable.Option[int]
+	Runtime             immutable.Option[module.Runtime]
+	BlockstoreNamespace immutable.Option[string]
+	BlockstoreChunkSize immutable.Option[int]
+	IndexstoreNamespace immutable.Option[string]
+	P2P                 immutable.Option[p2p.Host]
+	DisableP2P          bool
+
+	P2POptions []sourceP2P.NodeOpt
+}
+
+type Node struct {
+	onClose []closer
+	Options Options
+	Store   store.TxnStore
+	P2P     immutable.Option[*p2p.P2P]
+}
+
+func WithP2P(host p2p.Host) Option {
+	return func(opts *Options) {
+		opts.P2P = immutable.Some(host)
+	}
+}
+
+func WithP2PDisabled(disableP2P bool) Option {
+	return func(opts *Options) {
+		opts.DisableP2P = disableP2P
+	}
+}
+
+func WithP2Poptions(opts ...sourceP2P.NodeOpt) Option {
+	return func(opt *Options) {
+		opt.P2POptions = opts
+	}
+}
+
+func createNode(ctx context.Context, store store.TxnStore, o Options, onClose []closer) (*Node, error) {
+	var p2pSys immutable.Option[*p2p.P2P]
+	if !o.DisableP2P {
+		var host p2p.Host
+		if o.P2P.HasValue() {
+			host = o.P2P.Value()
+		} else {
+			p2pOptions := append(
+				o.P2POptions,
+				sourceP2P.WithBlockstoreNamespace(o.BlockstoreNamespace.Value()),
+				sourceP2P.WithRootstore(o.Rootstore.Value()),
+			)
+
+			if o.BlockstoreChunkSize.HasValue() {
+				p2pOptions = append(p2pOptions, sourceP2P.WithBlockstoreChunkSize(o.BlockstoreChunkSize.Value()))
+			}
+
+			var err error
+			host, err = sourceP2P.NewPeer(
+				ctx,
+				p2pOptions...,
+			)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		p2pSys = immutable.Some(p2p.New(host, o.Rootstore.Value(), o.IndexstoreNamespace.Value()))
+	}
+
+	return &Node{
+		onClose: onClose,
+		Options: o,
+		Store:   store,
+		P2P:     p2pSys,
+	}, nil
+}

--- a/host-go/node/node_p2p_free.go
+++ b/host-go/node/node_p2p_free.go
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build js
+
+package node
+
+import (
+	"context"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/immutable"
+
+	"github.com/sourcenetwork/lens/host-go/engine/module"
+	"github.com/sourcenetwork/lens/host-go/store"
+)
+
+type Options struct {
+	Path                immutable.Option[string]
+	Rootstore           immutable.Option[corekv.TxnReaderWriter]
+	TxnSource           immutable.Option[store.TxnSource]
+	PoolSize            immutable.Option[int]
+	Runtime             immutable.Option[module.Runtime]
+	BlockstoreNamespace immutable.Option[string]
+	BlockstoreChunkSize immutable.Option[int]
+	IndexstoreNamespace immutable.Option[string]
+	DisableP2P          bool
+}
+
+type Node struct {
+	onClose []closer
+	Options Options
+	Store   store.TxnStore
+}
+
+// WARNING - This option exists only for compatibility reasons, it can never have a
+// `false` value.
+func WithP2PDisabled(disableP2P bool) Option {
+	if !disableP2P {
+		panic("P2P cannot be enabled on JavaScript builds")
+	}
+
+	return func(opts *Options) {
+		opts.DisableP2P = disableP2P
+	}
+}
+
+func createNode(ctx context.Context, store store.TxnStore, o Options, onClose []closer) (*Node, error) {
+	return &Node{
+		onClose: onClose,
+		Options: o,
+		Store:   store,
+	}, nil
+}

--- a/host-go/node/option.go
+++ b/host-go/node/option.go
@@ -6,27 +6,10 @@ package node
 
 import (
 	"github.com/sourcenetwork/corekv"
-	sourceP2P "github.com/sourcenetwork/go-p2p"
 	"github.com/sourcenetwork/immutable"
 	"github.com/sourcenetwork/lens/host-go/engine/module"
-	"github.com/sourcenetwork/lens/host-go/p2p"
 	"github.com/sourcenetwork/lens/host-go/store"
 )
-
-type Options struct {
-	Path                immutable.Option[string]
-	Rootstore           immutable.Option[corekv.TxnReaderWriter]
-	TxnSource           immutable.Option[store.TxnSource]
-	PoolSize            immutable.Option[int]
-	Runtime             immutable.Option[module.Runtime]
-	BlockstoreNamespace immutable.Option[string]
-	BlockstoreChunkSize immutable.Option[int]
-	IndexstoreNamespace immutable.Option[string]
-	P2P                 immutable.Option[p2p.Host]
-	DisableP2P          bool
-
-	P2POptions []sourceP2P.NodeOpt
-}
 
 // Option is a funtion that sets a config value on the db.
 type Option func(*Options)
@@ -66,24 +49,6 @@ func WithBlockstoreNamespace(blockstoreNamespace string) Option {
 func WithIndextoreNamespace(indexstoreNamespace string) Option {
 	return func(opts *Options) {
 		opts.IndexstoreNamespace = immutable.Some(indexstoreNamespace)
-	}
-}
-
-func WithP2P(host p2p.Host) Option {
-	return func(opts *Options) {
-		opts.P2P = immutable.Some(host)
-	}
-}
-
-func WithP2PDisabled(disableP2P bool) Option {
-	return func(opts *Options) {
-		opts.DisableP2P = disableP2P
-	}
-}
-
-func WithP2Poptions(opts ...sourceP2P.NodeOpt) Option {
-	return func(opt *Options) {
-		opt.P2POptions = opts
 	}
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Resolves #137

## Description

Add JavaScript support to the `node` package, which didn't compile due to the go-p2p dependency.

Parts of the new integration tests do not work yet with JS as they reference go-p2p, this can be sorted out later.

Tested locally, using Lens' and Defra's `make test:js`.
