### PR TITLE
fix: Add MaxBlockSize option to JS build

### DIFF
--- a/host-go/node/node_p2p_free.go
+++ b/host-go/node/node_p2p_free.go
@@ -25,6 +25,7 @@ type Options struct {
 	Runtime             immutable.Option[module.Runtime]
 	BlockstoreNamespace immutable.Option[string]
 	BlockstoreChunkSize immutable.Option[int]
+	MaxBlockSize        immutable.Option[int]
 	IndexstoreNamespace immutable.Option[string]
 	DisableP2P          bool
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #146

## Description

Adds the MaxBlockSize option to JS build.

I missed this earlier, sorry about the bother.