### PR TITLE
fix: Empty transform ID error

### DIFF
--- a/host-go/store/store.go
+++ b/host-go/store/store.go
@@ -281,7 +281,13 @@ func getLinkPrototype() cidlink.LinkPrototype {
 	}}
 }
 
+// assertIsCid returns an error if the given input string is not a valid CID.
+//
+// Empty strings will never return an error since this is behavior DefraDB relies on.
 func assertIsCid(input string) error {
+	if input == "" {
+		return nil
+	}
 	_, err := cid.Parse(input)
 	return err
 }

--- a/tests/action/transform.go
+++ b/tests/action/transform.go
@@ -43,34 +43,38 @@ func (a *Transform) Execute() {
 
 		n.Transforms = append(n.Transforms, output)
 
-		for i := 0; true; i++ {
-			println(fmt.Sprintf("TransformEval: Node: {%v} item: {%v}", nodeIndex, i))
+		if output != nil {
+			for i := 0; true; i++ {
+				println(fmt.Sprintf("TransformEval: Node: {%v} item: {%v}", nodeIndex, i))
 
-			hasNext, err := output.Next()
-			require.NoError(a.s.T, err)
+				hasNext, err := output.Next()
+				require.NoError(a.s.T, err)
 
-			expectedHasNext, err := a.Expected.Next()
-			require.NoError(a.s.T, err)
+				expectedHasNext, err := a.Expected.Next()
+				require.NoError(a.s.T, err)
 
-			require.Equal(a.s.T, expectedHasNext, hasNext)
+				require.Equal(a.s.T, expectedHasNext, hasNext)
 
-			if !hasNext {
-				break
+				if !hasNext {
+					break
+				}
+
+				value, err := output.Value()
+				require.NoError(a.s.T, err)
+
+				expectedValue, err := a.Expected.Value()
+				require.NoError(a.s.T, err)
+
+				require.Equal(a.s.T, expectedValue, value)
 			}
-
-			value, err := output.Value()
-			require.NoError(a.s.T, err)
-
-			expectedValue, err := a.Expected.Value()
-			require.NoError(a.s.T, err)
-
-			require.Equal(a.s.T, expectedValue, value)
 		}
 
-		expectedHasNext, err := a.Expected.Next()
-		require.NoError(a.s.T, err)
-		require.False(a.s.T, expectedHasNext)
+		if a.Expected != nil {
+			expectedHasNext, err := a.Expected.Next()
+			require.NoError(a.s.T, err)
+			require.False(a.s.T, expectedHasNext)
 
-		a.Expected.Reset()
+			a.Expected.Reset()
+		}
 	}
 }

--- a/tests/integration/node/transform_test.go
+++ b/tests/integration/node/transform_test.go
@@ -13,12 +13,13 @@ import (
 	"github.com/sourcenetwork/lens/tests/integration"
 )
 
-func TestTransform_EmptyString_Errors(t *testing.T) {
+func TestTransform_EmptyString(t *testing.T) {
+	// This test ensures that empty strings behave
+	// in a way that DefraDB depends upon.
 	test := &integration.Test{
 		Actions: []action.Action{
 			&action.Transform{
-				LensID:        "",
-				ExpectedError: "invalid cid: cid too short",
+				LensID: "",
 			},
 		},
 	}
@@ -26,13 +27,14 @@ func TestTransform_EmptyString_Errors(t *testing.T) {
 	test.Execute(t)
 }
 
-func TestTransform_InverseEmptyString_Errors(t *testing.T) {
+func TestTransform_InverseEmptyString(t *testing.T) {
+	// This test ensures that empty strings behave
+	// in a way that DefraDB depends upon.
 	test := &integration.Test{
 		Actions: []action.Action{
 			&action.Transform{
-				LensID:        "",
-				Inverse:       true,
-				ExpectedError: "invalid cid: cid too short",
+				LensID:  "",
+				Inverse: true,
 			},
 		},
 	}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #153

## Description

This PR fixes a new bug where empty IDs now return an error. The prior version of lens allowed for empty IDs so this new error has technically broken the public interface.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/validate-conventional-style.sh](tools/configs/validate-conventional-style.sh).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.

Specify the platform(s) on which this was tested:
- MacOS

