### PR TITLE
test: Add Rust lens host opt-in

### DIFF
--- a/tests/integration/cli/utlis.go
+++ b/tests/integration/cli/utlis.go
@@ -38,6 +38,12 @@ var hostExecutablePaths = []string{
 	),
 }
 
+func init() {
+	if rustHostPath := os.Getenv("DEFRADB_RS_LENS_HOST_BIN"); rustHostPath != "" {
+		hostExecutablePaths = append(hostExecutablePaths, rustHostPath)
+	}
+}
+
 func getPathRelativeToProjectRoot(relativePath string) string {
 	_, filename, _, _ := runtime.Caller(0)
 	root := path.Dir(path.Dir(path.Dir(path.Dir(filename))))


### PR DESCRIPTION
## Summary
- append `DEFRADB_RS_LENS_HOST_BIN` to the CLI host executable list when set
- keep default Lens test behavior unchanged when the env var is absent

## Rust Host Version Verified
- defradb.rs tag: `v0.12.0`
- defradb.rs release: https://github.com/sourcenetwork/defradb.rs/releases/tag/v0.12.0
- defradb.rs commit: `e4e018d9124cfc4b165db25cebaa2679df422cb6`
- local release binary used for verification: `/tmp/defradb-rs-v0.12.0/target/release/lens-host`

## Lens CLI tests passing against Rust host
- TestSimple
- TestSimpleWithNoModules
- TestSimpleWithEmptyItem
- TestSimpleWithNilItem
- TestSimpleWithModules
- TestSimpleWithModulesRepeated
- TestWithParams
- TestWithParamsReturnsErrorGivenBadParam
- TestWithParamsReturnsErrorGivenNilParam
- TestWithModulesWithParams
- TestInverse
- TestInverseErrorsGivenNoInverseAvailable
- TestInverseWithModules
- TestWithFilter
- TestWithNormalize
- TestWithMem
- TestWithModulesWithNormalizeWithParams
- TestWithState
- TestWithStateDuplicated

## Verification
- `cargo build -p lens-host --release` from defradb.rs `v0.12.0`
- `DEFRADB_RS_LENS_HOST_BIN=/tmp/defradb-rs-v0.12.0/target/release/lens-host go test -count=1 ./tests/integration/cli/...`
