### PR TITLE
fix: Wasm reset leak runtimes

### DIFF
--- a/host-go/engine/tests/reset_leak_test.go
+++ b/host-go/engine/tests/reset_leak_test.go
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/immutable/enumerable"
+	"github.com/sourcenetwork/lens/host-go/engine"
+	"github.com/sourcenetwork/lens/host-go/engine/module"
+	"github.com/sourcenetwork/lens/tests/modules"
+
+	"github.com/stretchr/testify/require"
+)
+
+// assertResetDoesNotLeak drives a single instance of the given runtime through many
+// pipe.Reset() cycles and asserts that wasm linear memory does not grow unboundedly.
+//
+// Without re-instantiation on Reset, dlmalloc-rs bookkeeping is overwritten on each
+// Reset, causing memory.grow to be called every cycle and leak ~64 KiB per call
+// (issues #155 and #159). Every runtime is exercised through this same helper.
+func assertResetDoesNotLeak(t *testing.T, rt module.Runtime) {
+	if testing.Short() {
+		t.Skip("skipping memory-growth test under -short")
+	}
+
+	const (
+		warmupCycles = 50
+		totalCycles  = 2_000
+		// Allow at most two extra 64 KiB pages after warm-up to absorb any
+		// legitimate one-time allocator adjustment; more than that indicates a leak.
+		maxGrowthBytes = uint32(2 * 64 * 1024)
+	)
+
+	mod, err := engine.NewModule(rt, modules.WasmPath1)
+	require.NoError(t, err)
+
+	instance, err := engine.NewInstance(mod)
+	require.NoError(t, err)
+
+	var baseline uint32
+	for cycle := 1; cycle <= totalCycles; cycle++ {
+		source := enumerable.New([]type1{{Name: "John", Age: cycle}})
+		pipe := engine.Append[type1, type2](source, instance)
+
+		hasNext, err := pipe.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext, "expected one record on cycle %d", cycle)
+
+		_, err = pipe.Value()
+		require.NoError(t, err)
+
+		hasNext, err = pipe.Next()
+		require.NoError(t, err)
+		require.False(t, hasNext, "expected EOS on cycle %d", cycle)
+
+		pipe.Reset()
+
+		if cycle == warmupCycles {
+			baseline = instance.Memory().Size()
+		}
+	}
+
+	final := instance.Memory().Size()
+	growth := final - baseline
+	require.LessOrEqualf(t, growth, maxGrowthBytes,
+		"wasm linear memory grew by %d bytes over %d Reset cycles "+
+			"(baseline after %d-cycle warm-up = %d bytes, final = %d bytes); "+
+			"expected growth <= %d bytes — Reset is likely leaking memory (issue #159)",
+		growth, totalCycles-warmupCycles, warmupCycles, baseline, final, maxGrowthBytes,
+	)
+}

--- a/host-go/engine/tests/wasm32_pipeline_reset_js_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_reset_js_test.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build js
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/lens/host-go/runtimes/js"
+)
+
+// TestJsResetDoesNotLeakMemory asserts the js runtime does not leak wasm linear
+// memory across Reset cycles (issue #159).
+func TestJsResetDoesNotLeakMemory(t *testing.T) {
+	assertResetDoesNotLeak(t, js.New())
+}

--- a/host-go/engine/tests/wasm32_pipeline_reset_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_reset_test.go
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Excluded on windows/js builds: those platforms default to the wazero/js runtimes, which
-// still reset by overwriting linear memory and therefore still leak (see issue #155).
+// Build-constrained to match the wasmtime runtime package, which is unavailable on
+// windows/js builds. The wazero, wasmer, and js runtimes have their own reset tests.
 //go:build !windows && !js
 
 package tests
@@ -11,67 +11,11 @@ package tests
 import (
 	"testing"
 
-	"github.com/sourcenetwork/immutable/enumerable"
-	"github.com/sourcenetwork/lens/host-go/engine"
-	"github.com/sourcenetwork/lens/tests/modules"
-
-	"github.com/stretchr/testify/require"
+	"github.com/sourcenetwork/lens/host-go/runtimes/wasmtime"
 )
 
-// TestWasm32ResetDoesNotLeakMemory drives a single instance through many pipe.Reset() cycles
-// and asserts that wasm linear memory does not grow unboundedly.
-//
-// Without the store-per-instance fix, dlmalloc-rs bookkeeping is overwritten on each Reset,
-// causing memory.grow to be called every cycle and leak ~64 KiB per call (issue #155).
+// TestWasm32ResetDoesNotLeakMemory asserts the wasmtime runtime does not leak wasm
+// linear memory across Reset cycles (issue #155).
 func TestWasm32ResetDoesNotLeakMemory(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping memory-growth test under -short")
-	}
-
-	const (
-		warmupCycles = 50
-		totalCycles  = 2_000
-		// Allow at most two extra 64 KiB pages after warm-up to absorb any
-		// legitimate one-time allocator adjustment; more than that indicates a leak.
-		maxGrowthBytes = uint32(2 * 64 * 1024)
-	)
-
-	rt := newRuntime()
-	mod, err := engine.NewModule(rt, modules.WasmPath1)
-	require.NoError(t, err)
-
-	instance, err := engine.NewInstance(mod)
-	require.NoError(t, err)
-
-	var baseline uint32
-	for cycle := 1; cycle <= totalCycles; cycle++ {
-		source := enumerable.New([]type1{{Name: "John", Age: cycle}})
-		pipe := engine.Append[type1, type2](source, instance)
-
-		hasNext, err := pipe.Next()
-		require.NoError(t, err)
-		require.True(t, hasNext, "expected one record on cycle %d", cycle)
-
-		_, err = pipe.Value()
-		require.NoError(t, err)
-
-		hasNext, err = pipe.Next()
-		require.NoError(t, err)
-		require.False(t, hasNext, "expected EOS on cycle %d", cycle)
-
-		pipe.Reset()
-
-		if cycle == warmupCycles {
-			baseline = instance.Memory().Size()
-		}
-	}
-
-	final := instance.Memory().Size()
-	growth := final - baseline
-	require.LessOrEqualf(t, growth, maxGrowthBytes,
-		"wasm linear memory grew by %d bytes over %d Reset cycles "+
-			"(baseline after %d-cycle warm-up = %d bytes, final = %d bytes); "+
-			"expected growth <= %d bytes — Reset is likely leaking memory (issue #155)",
-		growth, totalCycles-warmupCycles, warmupCycles, baseline, final, maxGrowthBytes,
-	)
+	assertResetDoesNotLeak(t, wasmtime.New())
 }

--- a/host-go/engine/tests/wasm32_pipeline_reset_wasmer_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_reset_wasmer_test.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !windows && !js
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/lens/host-go/runtimes/wasmer"
+)
+
+// TestWasmerResetDoesNotLeakMemory asserts the wasmer runtime does not leak wasm
+// linear memory across Reset cycles (issue #159).
+func TestWasmerResetDoesNotLeakMemory(t *testing.T) {
+	assertResetDoesNotLeak(t, wasmer.New())
+}

--- a/host-go/engine/tests/wasm32_pipeline_reset_wazero_test.go
+++ b/host-go/engine/tests/wasm32_pipeline_reset_wazero_test.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !js
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/lens/host-go/runtimes/wazero"
+)
+
+// TestWazeroResetDoesNotLeakMemory asserts the wazero runtime does not leak wasm
+// linear memory across Reset cycles (issue #159).
+func TestWazeroResetDoesNotLeakMemory(t *testing.T) {
+	assertResetDoesNotLeak(t, wazero.New())
+}

--- a/host-go/runtimes/js/runtime.go
+++ b/host-go/runtimes/js/runtime.go
@@ -67,24 +67,32 @@ type wModule struct {
 
 var _ module.Module = (*wModule)(nil)
 
-func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) (module.Instance, error) {
-	var nextFunction = func() module.MemSize { return 0 }
-	// Register the `lens.next` function required as an import for wasm lens modules
-	importObject := map[string]any{
-		"lens": map[string]any{
-			"next": js.FuncOf(func(this js.Value, args []js.Value) any {
-				return nextFunction()
-			}),
-		},
-	}
+// instanceHandles holds all per-instance js resources. Storing them behind a pointer lets
+// Reset swap the contents in-place so that the Alloc/Transform/Memory closures — which all
+// capture the same *instanceHandles — automatically see the fresh instance.
+type instanceHandles struct {
+	instance  js.Value
+	memory    js.Value
+	alloc     js.Value
+	transform js.Value
+}
 
+// newInstanceHandles instantiates the module with the given importObject and applies
+// set_param when params is non-empty.
+func newInstanceHandles(
+	rt *wRuntime,
+	mod js.Value,
+	fnName string,
+	params map[string]any,
+	importObject map[string]any,
+) (*instanceHandles, error) {
 	// Instantiates a WebAssembly.Instance from a WebAssembly.Module with imports.
 	//
 	// https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiate_static
-	promise := m.runtime.webAssembly.Call("instantiate", m.module, importObject)
+	promise := rt.webAssembly.Call("instantiate", mod, importObject)
 	results, err := await(promise)
 	if err != nil {
-		return module.Instance{}, err
+		return nil, err
 	}
 	instance := results[0]
 
@@ -98,37 +106,28 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 	// https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Memory
 	memory := exports.Get("memory")
 	if memory.Type() != js.TypeObject {
-		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "memory"))
+		return nil, fmt.Errorf("Export `%s` does not exist", "memory")
 	}
 
 	alloc := exports.Get("alloc")
 	if alloc.Type() != js.TypeFunction {
-		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "alloc"))
+		return nil, fmt.Errorf("Export `%s` does not exist", "alloc")
 	}
 
-	transform := exports.Get(functionName)
+	transform := exports.Get(fnName)
 	if transform.Type() != js.TypeFunction {
-		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", functionName))
-	}
-
-	params := map[string]any{}
-	// Merge the param sets into a single map in case more than
-	// one map is provided.
-	for _, paramSet := range paramSets {
-		for key, value := range paramSet {
-			params[key] = value
-		}
+		return nil, fmt.Errorf("Export `%s` does not exist", fnName)
 	}
 
 	if len(params) > 0 {
 		setParam := exports.Get("set_param")
 		if setParam.Type() != js.TypeFunction {
-			return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "set_param"))
+			return nil, fmt.Errorf("Export `%s` does not exist", "set_param")
 		}
 
 		sourceBytes, err := json.Marshal(params)
 		if err != nil {
-			return module.Instance{}, err
+			return nil, err
 		}
 
 		// allocate memory to write to
@@ -138,7 +137,7 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 
 		err = pipes.WriteItem(w, module.JSONTypeID, sourceBytes)
 		if err != nil {
-			return module.Instance{}, err
+			return nil, err
 		}
 
 		// set param from JavaScript memory
@@ -149,46 +148,85 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 		// from memory using `pipes.GetItem`.
 		id, data, err := pipes.ReadItem(r)
 		if id.IsError() {
-			return module.Instance{}, errors.New(string(data))
+			return nil, errors.New(string(data))
 		}
 		if err != nil {
-			return module.Instance{}, err
+			return nil, err
 		}
 	}
 
-	jsMemory := js.Global().Get("Uint8Array").New(memory.Get("buffer"))
-	initialLen := jsMemory.Get("length").Int()
-	initialState := make([]byte, initialLen)
-	js.CopyBytesToGo(initialState, jsMemory)
+	return &instanceHandles{
+		instance:  instance,
+		memory:    memory,
+		alloc:     alloc,
+		transform: transform,
+	}, nil
+}
+
+func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) (module.Instance, error) {
+	params := map[string]any{}
+	// Merge the param sets into a single map in case more than
+	// one map is provided.
+	for _, paramSet := range paramSets {
+		for key, value := range paramSet {
+			params[key] = value
+		}
+	}
+
+	var nextFn = func() module.MemSize { return 0 }
+	// Register the `lens.next` function required as an import for wasm lens modules. The
+	// import object (and its single js.Func) is created once and reused across re-instantiation
+	// so Reset does not churn js callback registrations.
+	importObject := map[string]any{
+		"lens": map[string]any{
+			"next": js.FuncOf(func(this js.Value, args []js.Value) any {
+				return nextFn()
+			}),
+		},
+	}
+
+	handles, err := newInstanceHandles(m.runtime, m.module, functionName, params, importObject)
+	if err != nil {
+		return module.Instance{}, err
+	}
+
+	var resetErr error
 
 	return module.Instance{
 		Alloc: func(u module.MemSize) (module.MemSize, error) {
-			result := alloc.Invoke(int32(u))
+			if resetErr != nil {
+				return 0, resetErr
+			}
+			result := handles.alloc.Invoke(int32(u))
 			return module.MemSize(result.Int()), nil
 		},
 		Transform: func(next func() module.MemSize) (module.MemSize, error) {
+			if resetErr != nil {
+				return 0, resetErr
+			}
 			// By assigning the next function immediately prior to calling transform, we allow multiple
 			// pipeline stages to share the same wasm instance - provided they are not called concurrently.
 			// This also allows module state to be shared across pipeline stages.
-			nextFunction = next
-			result := transform.Invoke()
+			nextFn = next
+			result := handles.transform.Invoke()
 			return module.MemSize(result.Int()), nil
 		},
 		Memory: func() module.Memory {
-			buffer := memory.Get("buffer")
-			return newMemory(buffer)
+			return newMemory(handles.memory.Get("buffer"))
 		},
 		Reset: func() {
-			initialLen := len(initialState)
-			currentLen := jsMemory.Get("length").Int()
-
-			js.CopyBytesToJS(jsMemory, initialState)
-
-			for i := initialLen; i < currentLen; i++ {
-				jsMemory.SetIndex(i, js.ValueOf(0))
+			nextFn = func() module.MemSize { return 0 }
+			newHandles, err := newInstanceHandles(m.runtime, m.module, functionName, params, importObject)
+			if err != nil {
+				resetErr = err
+				return
 			}
+			resetErr = nil
+			*handles = *newHandles
+			// The displaced WebAssembly.Instance has no explicit close; dropping the reference
+			// lets the runtime GC reclaim its linear memory (issue #159).
 		},
-		OwnedBy: instance,
+		OwnedBy: handles,
 	}, nil
 }
 

--- a/host-go/runtimes/wasmer/runtime.go
+++ b/host-go/runtimes/wasmer/runtime.go
@@ -57,49 +57,117 @@ func (rt *wRuntime) NewModule(wasmBytes []byte) (module.Module, error) {
 	}, nil
 }
 
-func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) (module.Instance, error) {
+// instanceHandles holds all per-instance wasmer resources. Storing them behind a pointer
+// lets Reset swap the contents in-place so that the Alloc/Transform/Memory closures — which
+// all capture the same *instanceHandles — automatically see the fresh instance.
+type instanceHandles struct {
+	instance  *wasmer.Instance
+	memory    *wasmer.Memory
+	alloc     *wasmer.Function
+	transform *wasmer.Function
+}
+
+// newInstanceHandles instantiates mod against the shared store, wires the nextFnPtr import,
+// and applies set_param when params is non-empty.
+func newInstanceHandles(
+	store *wasmer.Store,
+	mod *wasmer.Module,
+	fnName string,
+	params map[string]any,
+	nextFnPtr *func() module.MemSize,
+) (*instanceHandles, error) {
 	importObject := wasmer.NewImportObject()
 
-	var nextFunction = func() module.MemSize { return 0 }
 	// Register the `lens.next` function required as an import for wasm lens modules
 	importObject.Register(
 		"lens",
 		map[string]wasmer.IntoExtern{
 			"next": wasmer.NewFunction(
-				m.runtime.store,
+				store,
 				wasmer.NewFunctionType(
 					wasmer.NewValueTypes(),
 					// Warning: wasmer requires a concrete type here and as such this line is coupled to the module's runtime
 					wasmer.NewValueTypes(wasmer.I32),
 				),
 				func(v []wasmer.Value) ([]wasmer.Value, error) {
-					r := nextFunction()
+					r := (*nextFnPtr)()
 					return []wasmer.Value{wasmer.NewI32(r)}, nil
 				},
 			),
 		},
 	)
 
-	instance, err := wasmer.NewInstance(m.module, importObject)
+	instance, err := wasmer.NewInstance(mod, importObject)
 	if err != nil {
-		return module.Instance{}, err
+		return nil, err
 	}
 
 	memory, err := instance.Exports.GetMemory("memory")
 	if err != nil {
-		return module.Instance{}, err
+		return nil, err
 	}
 
 	alloc, err := instance.Exports.GetRawFunction("alloc")
 	if err != nil {
-		return module.Instance{}, err
+		return nil, err
 	}
 
-	transform, err := instance.Exports.GetRawFunction(functionName)
+	transform, err := instance.Exports.GetRawFunction(fnName)
 	if err != nil {
-		return module.Instance{}, err
+		return nil, err
 	}
 
+	if len(params) > 0 {
+		setParam, err := instance.Exports.GetRawFunction("set_param")
+		if err != nil {
+			return nil, err
+		}
+
+		sourceBytes, err := json.Marshal(params)
+		if err != nil {
+			return nil, err
+		}
+
+		index, err := alloc.Call(module.TypeIdSize + module.MemSize(len(sourceBytes)) + module.LenSize)
+		if err != nil {
+			return nil, err
+		}
+
+		mem := module.NewBytesMemory(memory.Data())
+		w := io.NewOffsetWriter(mem, int64(index.(module.MemSize)))
+
+		err = pipes.WriteItem(w, module.JSONTypeID, sourceBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		index, err = setParam.Call(index)
+		if err != nil {
+			return nil, err
+		}
+
+		r := io.NewSectionReader(mem, int64(index.(module.MemSize)), math.MaxInt64)
+
+		// The `set_param` wasm function may error, in which case the error needs to be retrieved
+		// from memory using `pipes.GetItem`.
+		id, data, err := pipes.ReadItem(r)
+		if id.IsError() {
+			return nil, errors.New(string(data))
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &instanceHandles{
+		instance:  instance,
+		memory:    memory,
+		alloc:     alloc,
+		transform: transform,
+	}, nil
+}
+
+func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) (module.Instance, error) {
 	params := map[string]any{}
 	// Merge the param sets into a single map in case more than
 	// one map is provided.
@@ -109,84 +177,57 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 		}
 	}
 
-	if len(params) > 0 {
-		setParam, err := instance.Exports.GetRawFunction("set_param")
-		if err != nil {
-			return module.Instance{}, err
-		}
+	var nextFn func() module.MemSize = func() module.MemSize { return 0 }
 
-		sourceBytes, err := json.Marshal(params)
-		if err != nil {
-			return module.Instance{}, err
-		}
-
-		index, err := alloc.Call(module.TypeIdSize + module.MemSize(len(sourceBytes)) + module.LenSize)
-		if err != nil {
-			return module.Instance{}, err
-		}
-
-		mem := module.NewBytesMemory(memory.Data())
-		w := io.NewOffsetWriter(mem, int64(index.(module.MemSize)))
-
-		err = pipes.WriteItem(w, module.JSONTypeID, sourceBytes)
-		if err != nil {
-			return module.Instance{}, err
-		}
-
-		index, err = setParam.Call(index)
-		if err != nil {
-			return module.Instance{}, err
-		}
-
-		r := io.NewSectionReader(mem, int64(index.(module.MemSize)), math.MaxInt64)
-
-		// The `set_param` wasm function may error, in which case the error needs to be retrieved
-		// from memory using `pipes.GetItem`.
-		id, data, err := pipes.ReadItem(r)
-		if id.IsError() {
-			return module.Instance{}, errors.New(string(data))
-		}
-		if err != nil {
-			return module.Instance{}, err
-		}
+	handles, err := newInstanceHandles(m.runtime.store, m.module, functionName, params, &nextFn)
+	if err != nil {
+		return module.Instance{}, err
 	}
 
-	memSlice := memory.Data()
-	initialState := make([]byte, len(memSlice))
-	copy(initialState, memSlice)
+	var resetErr error
 
 	return module.Instance{
 		Alloc: func(u module.MemSize) (module.MemSize, error) {
-			r, err := alloc.Call(u)
+			if resetErr != nil {
+				return 0, resetErr
+			}
+			r, err := handles.alloc.Call(u)
 			if err != nil {
 				return 0, err
 			}
 			return r.(module.MemSize), err
 		},
 		Transform: func(next func() module.MemSize) (module.MemSize, error) {
+			if resetErr != nil {
+				return 0, resetErr
+			}
 			// By assigning the next function immediately prior to calling transform, we allow multiple
 			// pipeline stages to share the same wasm instance - provided they are not called concurrently.
 			// This also allows module state to be shared across pipeline stages.
-			nextFunction = next
-			r, err := transform.Call()
+			nextFn = next
+			r, err := handles.transform.Call()
 			if err != nil {
 				return 0, err
 			}
 			return r.(module.MemSize), err
 		},
 		Memory: func() module.Memory {
-			return module.NewBytesMemory(memory.Data())
+			return module.NewBytesMemory(handles.memory.Data())
 		},
 		Reset: func() {
-			initialLen := len(initialState)
-			currentMemory := memory.Data()
-
-			copy(currentMemory, initialState)
-
-			for i := initialLen; i < len(currentMemory); i++ {
-				currentMemory[i] = 0
+			nextFn = func() module.MemSize { return 0 }
+			newHandles, err := newInstanceHandles(m.runtime.store, m.module, functionName, params, &nextFn)
+			if err != nil {
+				resetErr = err
+				return
 			}
+			resetErr = nil
+			oldInstance := handles.instance
+			*handles = *newHandles
+			// Free the old instance's C-allocated linear memory now; the GC finalizer would do
+			// it eventually but wasm memory exerts no Go heap pressure (issue #159).
+			oldInstance.Close()
 		},
-		OwnedBy: instance,
+		OwnedBy: handles,
 	}, nil
 }

--- a/host-go/runtimes/wazero/memory.go
+++ b/host-go/runtimes/wazero/memory.go
@@ -24,7 +24,6 @@ func (m *memory) WriteAt(src []byte, offset int64) (int, error) {
 }
 
 func (m *memory) Size() uint32 {
-	// wasm linear memory grows in 64 KiB pages per the spec.
-	const wasmPageSize = 65536
-	return m.memory.Size() * wasmPageSize
+	// wazero's api.Memory.Size already reports the size in bytes.
+	return m.memory.Size()
 }

--- a/host-go/runtimes/wazero/runtime.go
+++ b/host-go/runtimes/wazero/runtime.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcenetwork/lens/host-go/engine/pipes"
 
 	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
 )
 
 const Name string = "wazero"
@@ -56,43 +57,113 @@ func (rt *wRuntime) NewModule(wasmBytes []byte) (module.Module, error) {
 	}, nil
 }
 
-func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) (module.Instance, error) {
-	ctx := context.TODO()
-	runtimeConfig := wazero.NewRuntimeConfig().WithCompilationCache(m.compilationCache)
-	runtime := wazero.NewRuntimeWithConfig(ctx, runtimeConfig)
+// instanceHandles holds all per-instance wazero resources. Storing them behind a pointer
+// lets Reset swap the contents in-place so that the Alloc/Transform/Memory closures — which
+// all capture the same *instanceHandles — automatically see the fresh runtime.
+type instanceHandles struct {
+	runtime   wazero.Runtime
+	instance  api.Module
+	memory    api.Memory
+	alloc     api.Function
+	transform api.Function
+}
 
-	var nextFunction = func() module.MemSize { return 0 }
-	_, err := runtime.NewHostModuleBuilder("lens").
+// newInstanceHandles creates a fresh wazero runtime (reusing the shared compilation cache),
+// wires the nextFnPtr import, instantiates the module, and applies set_param when params is
+// non-empty.
+func newInstanceHandles(
+	compilationCache wazero.CompilationCache,
+	moduleBytes []byte,
+	fnName string,
+	params map[string]any,
+	nextFnPtr *func() module.MemSize,
+) (*instanceHandles, error) {
+	ctx := context.TODO()
+	runtimeConfig := wazero.NewRuntimeConfig().WithCompilationCache(compilationCache)
+	rt := wazero.NewRuntimeWithConfig(ctx, runtimeConfig)
+
+	_, err := rt.NewHostModuleBuilder("lens").
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context) module.MemSize {
-			return nextFunction()
+			return (*nextFnPtr)()
 		}).
 		Export("next").
 		Instantiate(ctx)
 	if err != nil {
-		return module.Instance{}, err
+		return nil, err
 	}
 
-	instance, err := runtime.Instantiate(ctx, m.moduleBytes)
+	inst, err := rt.Instantiate(ctx, moduleBytes)
 	if err != nil {
-		return module.Instance{}, err
+		return nil, err
 	}
 
-	memory := instance.ExportedMemory("memory")
+	memory := inst.ExportedMemory("memory")
 	if memory == nil {
-		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "memory"))
+		return nil, fmt.Errorf("Export `%s` does not exist", "memory")
 	}
 
-	alloc := instance.ExportedFunction("alloc")
+	alloc := inst.ExportedFunction("alloc")
 	if alloc == nil {
-		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "alloc"))
+		return nil, fmt.Errorf("Export `%s` does not exist", "alloc")
 	}
 
-	transform := instance.ExportedFunction(functionName)
+	transform := inst.ExportedFunction(fnName)
 	if transform == nil {
-		return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", functionName))
+		return nil, fmt.Errorf("Export `%s` does not exist", fnName)
 	}
 
+	if len(params) > 0 {
+		setParam := inst.ExportedFunction("set_param")
+		if setParam == nil {
+			return nil, fmt.Errorf("Export `%s` does not exist", "set_param")
+		}
+
+		sourceBytes, err := json.Marshal(params)
+		if err != nil {
+			return nil, err
+		}
+
+		index, err := alloc.Call(ctx, uint64(module.TypeIdSize+module.MemSize(len(sourceBytes))+module.LenSize))
+		if err != nil {
+			return nil, err
+		}
+
+		mem := newMemory(memory)
+		w := io.NewOffsetWriter(mem, int64(index[0]))
+
+		err = pipes.WriteItem(w, module.JSONTypeID, sourceBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		index, err = setParam.Call(ctx, index[0])
+		if err != nil {
+			return nil, err
+		}
+		r := io.NewSectionReader(mem, int64(index[0]), math.MaxInt64)
+
+		// The `set_param` wasm function may error, in which case the error needs to be retrieved
+		// from memory using `pipes.GetItem`.
+		id, data, err := pipes.ReadItem(r)
+		if id.IsError() {
+			return nil, errors.New(string(data))
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &instanceHandles{
+		runtime:   rt,
+		instance:  inst,
+		memory:    memory,
+		alloc:     alloc,
+		transform: transform,
+	}, nil
+}
+
+func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) (module.Instance, error) {
 	params := map[string]any{}
 	// Merge the param sets into a single map in case more than
 	// one map is provided.
@@ -102,80 +173,58 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 		}
 	}
 
-	if len(params) > 0 {
-		setParam := instance.ExportedFunction("set_param")
-		if err != nil {
-			return module.Instance{}, errors.New(fmt.Sprintf("Export `%s` does not exist", "set_param"))
-		}
+	var nextFn func() module.MemSize = func() module.MemSize { return 0 }
 
-		sourceBytes, err := json.Marshal(params)
-		if err != nil {
-			return module.Instance{}, err
-		}
-
-		index, err := alloc.Call(ctx, uint64(module.TypeIdSize+module.MemSize(len(sourceBytes))+module.LenSize))
-		if err != nil {
-			return module.Instance{}, err
-		}
-
-		mem := newMemory(memory)
-		w := io.NewOffsetWriter(mem, int64(index[0]))
-
-		err = pipes.WriteItem(w, module.JSONTypeID, sourceBytes)
-		if err != nil {
-			return module.Instance{}, err
-		}
-
-		index, err = setParam.Call(ctx, index[0])
-		if err != nil {
-			return module.Instance{}, err
-		}
-		r := io.NewSectionReader(mem, int64(index[0]), math.MaxInt64)
-
-		// The `set_param` wasm function may error, in which case the error needs to be retrieved
-		// from memory using `pipes.GetItem`.
-		id, data, err := pipes.ReadItem(r)
-		if id.IsError() {
-			return module.Instance{}, errors.New(string(data))
-		}
-		if err != nil {
-			return module.Instance{}, err
-		}
+	handles, err := newInstanceHandles(m.compilationCache, m.moduleBytes, functionName, params, &nextFn)
+	if err != nil {
+		return module.Instance{}, err
 	}
 
-	initialState, _ := memory.Read(0, memory.Size())
+	ctx := context.TODO()
+	var resetErr error
 
 	return module.Instance{
 		Alloc: func(u module.MemSize) (module.MemSize, error) {
-			r, err := alloc.Call(ctx, uint64(u))
+			if resetErr != nil {
+				return 0, resetErr
+			}
+			r, err := handles.alloc.Call(ctx, uint64(u))
 			if err != nil {
 				return 0, err
 			}
 			return module.MemSize(r[0]), nil
 		},
 		Transform: func(next func() module.MemSize) (module.MemSize, error) {
+			if resetErr != nil {
+				return 0, resetErr
+			}
 			// By assigning the next function immediately prior to calling transform, we allow multiple
 			// pipeline stages to share the same wasm instance - provided they are not called concurrently.
 			// This also allows module state to be shared across pipeline stages.
-			nextFunction = next
-			r, err := transform.Call(ctx)
+			nextFn = next
+			r, err := handles.transform.Call(ctx)
 			if err != nil {
 				return 0, err
 			}
 			return module.MemSize(r[0]), nil
 		},
 		Memory: func() module.Memory {
-			return newMemory(memory)
+			return newMemory(handles.memory)
 		},
 		Reset: func() {
-			initialLen := uint32(len(initialState))
-			currentLen := memory.Size()
-			memory.Write(0, initialState)
-
-			for i := initialLen; i < currentLen; i++ {
-				memory.WriteByte(i, 0)
+			nextFn = func() module.MemSize { return 0 }
+			newHandles, err := newInstanceHandles(m.compilationCache, m.moduleBytes, functionName, params, &nextFn)
+			if err != nil {
+				resetErr = err
+				return
 			}
+			resetErr = nil
+			oldRuntime := handles.runtime
+			*handles = *newHandles
+			// Free the old runtime (and its instance and linear memory) now rather than waiting
+			// for the GC, mirroring the wasmtime fix (issue #159).
+			_ = oldRuntime.Close(ctx)
 		},
-		OwnedBy: instance,
+		OwnedBy: handles,
 	}, nil
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #159 

## Description
The wazero, wasmer, and js runtimes leaked wasm linear memory on every `Reset()`, exactly as wasmtime did before #155/#157. All three still used the snapshot-restore strategy (overwrite linear memory back to a captured `initialState` and zero the tail).

**Fix (Port on-instantiate-Reset)**
Each runtime now keeps per-instance resources in an `instanceHandles` struct created by a `newInstanceHandles` factory. `Alloc`/`Transform`/`Memory` close over the `*instanceHandles`, so `Reset` rebuilds a fresh instance, swaps it in-place (`*handles = *newHandles`), and disposes the old one. `resetErr` surfaces a failed re-instantiation on the next `Alloc`/`Transform` (since `Reset` has no error return).

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/validate-conventional-style.sh](tools/configs/validate-conventional-style.sh).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
  - **Regression coverage**: extracted the shared `assertResetDoesNotLeak` helper (`host-go/engine/tests/reset_leak_test.go`, 2,000 Append/Reset cycles, asserts wasm linear-memory growth ≤ 2 pages after a 50-cycle warm-up) and added per-runtime test files build-tagged for wasmtime, wazero, wasmer, and js. Each was confirmed RED before its fix and GREEN after (wasmer: 1.2 MB → 14 MB over 200 cycles before, flat after; js: crashed before, passes after).
  - Full host-go suite (`make test`), js suite (`make test:js` via `go_js_wasm_exec`), and integration `node`/`cli` suites all pass.
  - `go vet ./...`, `gofmt`, and cross-compilation for `GOOS=js GOARCH=wasm` and
    `GOOS=windows` all pass.

Specify the platform(s) on which this was tested:
- MacOS

Disclosure: (wazero is the windows default and is exercised directly on MacOS via `wazero.New()`;
  windows and js builds were verified by cross-compilation.) 


