### PR TITLE
fix: Close wasm resources on error

### DIFF
--- a/host-go/engine/tests/new_instance_error_js_test.go
+++ b/host-go/engine/tests/new_instance_error_js_test.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build js
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/lens/host-go/runtimes/js"
+)
+
+// TestJsNewInstanceErrorReturnsError guards that an errored NewInstance still surfaces
+// its error after the next import is released on failure (issue #158).
+func TestJsNewInstanceErrorReturnsError(t *testing.T) {
+	assertNewInstanceErrorsOnUnknownParam(t, js.New())
+}

--- a/host-go/engine/tests/new_instance_error_test.go
+++ b/host-go/engine/tests/new_instance_error_test.go
@@ -18,6 +18,10 @@ import (
 // WasmPath1 has no `set_param` export, so providing params makes the factory fail after
 // the store/runtime/instance has been created. It asserts the error is still surfaced —
 // guarding against the error-path cleanup (issue #158) swallowing it.
+//
+// This is a regression guard, not a leak assertion: the resource freed by the #158
+// cleanup is C-allocated/host memory invisible to Go's GC, so a leak cannot be observed
+// in-tree (cf. #157). Actual reclamation is verified out-of-tree via host RSS.
 func assertNewInstanceErrorsOnUnknownParam(t *testing.T, rt module.Runtime) {
 	mod, err := engine.NewModule(rt, modules.WasmPath1)
 	require.NoError(t, err)

--- a/host-go/engine/tests/new_instance_error_test.go
+++ b/host-go/engine/tests/new_instance_error_test.go
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/lens/host-go/engine"
+	"github.com/sourcenetwork/lens/host-go/engine/module"
+	"github.com/sourcenetwork/lens/tests/modules"
+
+	"github.com/stretchr/testify/require"
+)
+
+// assertNewInstanceErrorsOnUnknownParam drives NewInstance into a factory error path:
+// WasmPath1 has no `set_param` export, so providing params makes the factory fail after
+// the store/runtime/instance has been created. It asserts the error is still surfaced —
+// guarding against the error-path cleanup (issue #158) swallowing it.
+func assertNewInstanceErrorsOnUnknownParam(t *testing.T, rt module.Runtime) {
+	mod, err := engine.NewModule(rt, modules.WasmPath1)
+	require.NoError(t, err)
+
+	_, err = engine.NewInstance(mod, map[string]any{"unknown": "param"})
+	require.Error(t, err)
+}

--- a/host-go/engine/tests/new_instance_error_wasmer_test.go
+++ b/host-go/engine/tests/new_instance_error_wasmer_test.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !windows && !js
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/lens/host-go/runtimes/wasmer"
+)
+
+// TestWasmerNewInstanceErrorReturnsError guards that an errored NewInstance still
+// surfaces its error after the factory closes the instance on failure (issue #158).
+func TestWasmerNewInstanceErrorReturnsError(t *testing.T) {
+	assertNewInstanceErrorsOnUnknownParam(t, wasmer.New())
+}

--- a/host-go/engine/tests/new_instance_error_wasmtime_test.go
+++ b/host-go/engine/tests/new_instance_error_wasmtime_test.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !windows && !js
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/lens/host-go/runtimes/wasmtime"
+)
+
+// TestWasmtimeNewInstanceErrorReturnsError guards that an errored NewInstance still
+// surfaces its error after the factory closes the store on failure (issue #158).
+func TestWasmtimeNewInstanceErrorReturnsError(t *testing.T) {
+	assertNewInstanceErrorsOnUnknownParam(t, wasmtime.New())
+}

--- a/host-go/engine/tests/new_instance_error_wazero_test.go
+++ b/host-go/engine/tests/new_instance_error_wazero_test.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !js
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/lens/host-go/runtimes/wazero"
+)
+
+// TestWazeroNewInstanceErrorReturnsError guards that an errored NewInstance still
+// surfaces its error after the factory closes the runtime on failure (issue #158).
+func TestWazeroNewInstanceErrorReturnsError(t *testing.T) {
+	assertNewInstanceErrorsOnUnknownParam(t, wazero.New())
+}

--- a/host-go/runtimes/js/runtime.go
+++ b/host-go/runtimes/js/runtime.go
@@ -177,16 +177,20 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 	// Register the `lens.next` function required as an import for wasm lens modules. The
 	// import object (and its single js.Func) is created once and reused across re-instantiation
 	// so Reset does not churn js callback registrations.
+	nextImport := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return nextFn()
+	})
 	importObject := map[string]any{
 		"lens": map[string]any{
-			"next": js.FuncOf(func(this js.Value, args []js.Value) any {
-				return nextFn()
-			}),
+			"next": nextImport,
 		},
 	}
 
 	handles, err := newInstanceHandles(m.runtime, m.module, functionName, params, importObject)
 	if err != nil {
+		// The instance is never returned, so release the host callback registration we
+		// created above rather than leaking it (issue #158).
+		nextImport.Release()
 		return module.Instance{}, err
 	}
 

--- a/host-go/runtimes/wasmer/runtime.go
+++ b/host-go/runtimes/wasmer/runtime.go
@@ -75,7 +75,7 @@ func newInstanceHandles(
 	fnName string,
 	params map[string]any,
 	nextFnPtr *func() module.MemSize,
-) (*instanceHandles, error) {
+) (_ *instanceHandles, err error) {
 	importObject := wasmer.NewImportObject()
 
 	// Register the `lens.next` function required as an import for wasm lens modules
@@ -101,6 +101,13 @@ func newInstanceHandles(
 	if err != nil {
 		return nil, err
 	}
+	// Close the instance (freeing its C-allocated linear memory) if we fail before
+	// returning successfully; the shared store is left intact (issue #158).
+	defer func() {
+		if err != nil {
+			instance.Close()
+		}
+	}()
 
 	memory, err := instance.Exports.GetMemory("memory")
 	if err != nil {

--- a/host-go/runtimes/wasmtime/runtime.go
+++ b/host-go/runtimes/wasmtime/runtime.go
@@ -74,8 +74,15 @@ func newInstanceHandles(
 	fnName string,
 	params map[string]any,
 	nextFnPtr *func() module.MemSize,
-) (*instanceHandles, error) {
+) (_ *instanceHandles, err error) {
 	store := wasmtime.NewStore(eng)
+	// Close the store (freeing its instance and C-allocated linear memory) if we fail
+	// before returning successfully, so an errored NewInstance/Reset does not leak it (issue #158).
+	defer func() {
+		if err != nil {
+			store.Close()
+		}
+	}()
 
 	nextImport := wasmtime.WrapFunc(store, func() module.MemSize {
 		return (*nextFnPtr)()

--- a/host-go/runtimes/wazero/runtime.go
+++ b/host-go/runtimes/wazero/runtime.go
@@ -77,12 +77,19 @@ func newInstanceHandles(
 	fnName string,
 	params map[string]any,
 	nextFnPtr *func() module.MemSize,
-) (*instanceHandles, error) {
+) (_ *instanceHandles, err error) {
 	ctx := context.TODO()
 	runtimeConfig := wazero.NewRuntimeConfig().WithCompilationCache(compilationCache)
 	rt := wazero.NewRuntimeWithConfig(ctx, runtimeConfig)
+	// Close the runtime (and the instance/memory it owns) if we fail before returning
+	// successfully, so an errored NewInstance/Reset does not leak it (issue #158).
+	defer func() {
+		if err != nil {
+			_ = rt.Close(ctx)
+		}
+	}()
 
-	_, err := rt.NewHostModuleBuilder("lens").
+	_, err = rt.NewHostModuleBuilder("lens").
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context) module.MemSize {
 			return (*nextFnPtr)()

--- a/host-go/runtimes/wazero/runtime.go
+++ b/host-go/runtimes/wazero/runtime.go
@@ -82,7 +82,8 @@ func newInstanceHandles(
 	runtimeConfig := wazero.NewRuntimeConfig().WithCompilationCache(compilationCache)
 	rt := wazero.NewRuntimeWithConfig(ctx, runtimeConfig)
 	// Close the runtime (and the instance/memory it owns) if we fail before returning
-	// successfully, so an errored NewInstance/Reset does not leak it (issue #158).
+	// successfully, so an errored NewInstance/Reset does not leak it (issue #158). The
+	// close error is discarded so it cannot mask the construction error we return.
 	defer func() {
 		if err != nil {
 			_ = rt.Close(ctx)
@@ -229,7 +230,9 @@ func (m *wModule) NewInstance(functionName string, paramSets ...map[string]any) 
 			oldRuntime := handles.runtime
 			*handles = *newHandles
 			// Free the old runtime (and its instance and linear memory) now rather than waiting
-			// for the GC, mirroring the wasmtime fix (issue #159).
+			// for the GC, mirroring the wasmtime fix (issue #159). The close error is intentionally
+			// discarded, not routed to resetErr: it concerns cleanup of the old, already-replaced
+			// runtime and must not fail Alloc/Transform on the freshly-built instance.
 			_ = oldRuntime.Close(ctx)
 		},
 		OwnedBy: handles,


### PR DESCRIPTION
## Relevant issue(s)

Resolves #158 

## Description
`newInstanceHandles` (in each runtime) creates its store/runtime/instance up front, then has several early `return ..., err` paths — missing exports, `json.Marshal`, `alloc.Call`, `set_param.Call`, `pipes.ReadItem` — that returned **without freeing the just-created resource**. So an errored `NewInstance` or `Reset` leaked a wasm store/runtime/instance.

**Fix (close per-instance resource on every path to factory)**
 using the idiomatic named-return + `defer` guard (fires only when the function returns an error; the success path never closes). The resource and mechanism differ per runtime
  - **wasmtime**: `defer store.Close()` after the store is created (`Store.Close()` is void).
  - **wazero**: `defer _ = rt.Close(ctx)` after the runtime is created (`Runtime.Close`
    returns an error, which is discarded so it can't mask the construction error).
  - **wasmer**: `defer instance.Close()` after a successful `NewInstance`; the shared
    store is intentionally left intact.
  - **js**: the instance `js.Value` is GC-reclaimed, but the `next` `js.FuncOf` callback
    registration would leak — it's `.Release()`d when the factory errors (only on the
    initial `NewInstance` failure; `Reset` reuses it for the instance's lifetime).

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/validate-conventional-style.sh](tools/configs/validate-conventional-style.sh).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?
 - **Guard tests** (`host-go/engine/tests/new_instance_error_*_test.go` + shared `assertNewInstanceErrorsOnUnknownParam` helper): drive a deterministic factory error (params on `WasmPath1`, which has no `set_param`) and assert `NewInstance` still surfaces its error — guarding against the named-return `defer` swallowing it. One per runtime: wasmtime, wazero, wasmer, js.
 
Specify the platform(s) on which this was tested:
- MacOS
