### PR TITLE
feat: Delete lens

### DIFF
--- a/host-go/repository/repository.go
+++ b/host-go/repository/repository.go
@@ -59,6 +59,9 @@ type Repository interface {
 		source enumerable.Enumerable[Document],
 		id string,
 	) (enumerable.Enumerable[Document], error)
+
+	// Delete removes any cached lenses for the given id. It is idempotent.
+	Delete(ctx context.Context, id string) error
 }
 
 // repository is responsible for managing all migration related state within a local
@@ -91,6 +94,10 @@ type txnContext struct {
 	txn               Txn
 	lensPoolsByID     map[string]*pool
 	reversedPoolsByID map[string]*pool
+
+	// deleted holds the ids tombstoned within this transaction. They are hidden from
+	// reads before commit and removed from the shared pools on commit.
+	deleted map[string]struct{}
 }
 
 func newTxnCtx(txn Txn) *txnContext {
@@ -98,6 +105,7 @@ func newTxnCtx(txn Txn) *txnContext {
 		txn:               txn,
 		lensPoolsByID:     map[string]*pool{},
 		reversedPoolsByID: map[string]*pool{},
+		deleted:           map[string]struct{}{},
 	}
 }
 
@@ -145,6 +153,13 @@ func (r *repository) getCtx(txn Txn, readonly bool) *txnContext {
 		for id, locker := range txnCtx.reversedPoolsByID {
 			r.reversedPoolsByID[id] = locker
 		}
+		// Apply tombstones after the additive merge. A single id covers both the forward
+		// and reversed pools. The write-time invariant (see `add`/`delete_`) guarantees an
+		// id is never both re-added and tombstoned, so ordering here is unambiguous.
+		for id := range txnCtx.deleted {
+			delete(r.lensPoolsByID, id)
+			delete(r.reversedPoolsByID, id)
+		}
 		r.poolLock.Unlock()
 
 		r.txnLock.Lock()
@@ -191,6 +206,10 @@ func (r *repository) add(
 		Lenses: inversedModuleCfgs,
 	}
 
+	// A re-add within the same transaction overrides any prior tombstone, keeping the
+	// invariant that an id is never both staged and tombstoned at commit time.
+	delete(txnCtx.deleted, id)
+
 	err := r.cachePool(txnCtx.lensPoolsByID, cfg, id)
 	if err != nil {
 		return err
@@ -203,6 +222,17 @@ func (r *repository) add(
 	}
 
 	return nil
+}
+
+// delete_ tombstones the given id within the transaction context. The pools are dropped
+// from the shared maps when the transaction commits. It is idempotent.
+//
+// Pools and pipes have no explicit teardown (GC-based); a pipe borrowed mid-flight keeps
+// its pool channel alive via Go reference semantics, so dropping the map entry is safe.
+func (r *repository) delete_(txnCtx *txnContext, id string) {
+	delete(txnCtx.lensPoolsByID, id)
+	delete(txnCtx.reversedPoolsByID, id)
+	txnCtx.deleted[id] = struct{}{}
 }
 
 func (r *repository) cachePool(
@@ -230,7 +260,7 @@ func (r *repository) transform(
 	src enumerable.Enumerable[Document],
 	id string,
 ) (enumerable.Enumerable[Document], error) {
-	return r.appendLens(r.lensPoolsByID, txnCtx.lensPoolsByID, src, id)
+	return r.appendLens(r.lensPoolsByID, txnCtx.lensPoolsByID, txnCtx.deleted, src, id)
 }
 
 func (r *repository) inverse(
@@ -238,16 +268,17 @@ func (r *repository) inverse(
 	src enumerable.Enumerable[Document],
 	id string,
 ) (enumerable.Enumerable[Document], error) {
-	return r.appendLens(r.reversedPoolsByID, txnCtx.reversedPoolsByID, src, id)
+	return r.appendLens(r.reversedPoolsByID, txnCtx.reversedPoolsByID, txnCtx.deleted, src, id)
 }
 
 func (r *repository) appendLens(
 	pools map[string]*pool,
 	txnPools map[string]*pool,
+	deleted map[string]struct{},
 	src enumerable.Enumerable[Document],
 	id string,
 ) (enumerable.Enumerable[Document], error) {
-	lensPool, ok := r.getPool(pools, txnPools, id)
+	lensPool, ok := r.getPool(pools, txnPools, deleted, id)
 	if !ok {
 		// If there are no migrations for this schema version, just return the given source.
 		return src, nil
@@ -266,10 +297,15 @@ func (r *repository) appendLens(
 func (r *repository) getPool(
 	pools map[string]*pool,
 	txnPools map[string]*pool,
+	deleted map[string]struct{},
 	id string,
 ) (*pool, bool) {
 	if pool, ok := txnPools[id]; ok {
 		return pool, true
+	}
+	if _, ok := deleted[id]; ok {
+		// Tombstoned within this transaction - hide it from reads before commit.
+		return nil, false
 	}
 
 	r.poolLock.RLock()

--- a/host-go/repository/txn_repository.go
+++ b/host-go/repository/txn_repository.go
@@ -51,6 +51,23 @@ func (r *explicitTxnRepository) Add(ctx context.Context, collectionID string, cf
 	return r.repository.add(r.repository.getCtx(r.txn, false), collectionID, cfg)
 }
 
+func (r *implicitTxnRepository) Delete(ctx context.Context, id string) error {
+	txn, err := r.db.NewTxn(false)
+	if err != nil {
+		return err
+	}
+	defer txn.Discard()
+
+	r.repository.delete_(r.repository.getCtx(txn, false), id)
+
+	return txn.Commit()
+}
+
+func (r *explicitTxnRepository) Delete(ctx context.Context, id string) error {
+	r.repository.delete_(r.repository.getCtx(r.txn, false), id)
+	return nil
+}
+
 func (r *implicitTxnRepository) Transform(
 	ctx context.Context,
 	src enumerable.Enumerable[Document],

--- a/host-go/store/store.go
+++ b/host-go/store/store.go
@@ -35,6 +35,14 @@ type Store interface {
 	// List fetches all the stored Lenses from the store and returns them mapped by their content ID.
 	List(ctx context.Context) (map[string]model.Lens, error)
 
+	// Delete removes the Lens with the given content ID.
+	//
+	// It is idempotent: no error is returned if the id is unknown or already removed.
+	//
+	// The content-addressed config and module blocks are left in the blockstore as they may be
+	// shared between lens configs; the lens is removed from `List` once its index entry is gone.
+	Delete(ctx context.Context, id string) error
+
 	// Reload fetches all stored Lenses and uses them to overwrite any cached instances held by the in
 	// memory wasm instance repository.
 	//

--- a/host-go/store/store.go
+++ b/host-go/store/store.go
@@ -162,6 +162,35 @@ func add(ctx context.Context, cfg model.Lens, txn *txn) (string, error) {
 	return configCID.String(), nil
 }
 
+func delete_(ctx context.Context, id string, txn *txn) error {
+	if err := assertIsCid(id); err != nil {
+		return err
+	}
+
+	configCID, err := cid.Parse(id)
+	if err != nil {
+		return err
+	}
+
+	// Remove the index entry that drives `list`. The content-addressed config and module
+	// blocks are intentionally left in the blockstore as they may be shared between configs.
+	//
+	// `cid.Bytes()` matches the key written by `add` (`configLink.Binary()`) and by the p2p
+	// `syncLens`.
+	key := configCID.Bytes()
+	has, err := txn.indexstore.Has(ctx, key)
+	if err != nil {
+		return err
+	}
+	if has {
+		if err := txn.indexstore.Delete(ctx, key); err != nil {
+			return err
+		}
+	}
+
+	return txn.repository.Delete(ctx, id)
+}
+
 func list(ctx context.Context, txn *txn) (map[string]model.Lens, error) {
 	iter, err := txn.indexstore.Iterator(
 		ctx,

--- a/host-go/store/store.go
+++ b/host-go/store/store.go
@@ -267,8 +267,10 @@ func reload(ctx context.Context, txn *txn) error {
 		}
 	}
 
-	// todo - keys will not be removed from the repository until
-	// https://github.com/sourcenetwork/lens/issues/118
+	// note - `Delete` (#118) keeps the index and repository in sync for the normal path.
+	// `reload` is still purely additive: it does not purge repository pools whose index
+	// entries were removed out-of-band. Diffing the cached ids against the index would
+	// require the repository to expose its id set; left as a follow-up.
 
 	return nil
 }

--- a/host-go/store/txn_store.go
+++ b/host-go/store/txn_store.go
@@ -109,6 +109,16 @@ func (s *explicitTxnStore) List(ctx context.Context) (map[string]model.Lens, err
 	return list(ctx, s.txn)
 }
 
+func (s *implicitTxnStore) Delete(ctx context.Context, id string) error {
+	// red stub - intentionally a no-op until the green commit.
+	return nil
+}
+
+func (s *explicitTxnStore) Delete(ctx context.Context, id string) error {
+	// red stub - intentionally a no-op until the green commit.
+	return nil
+}
+
 func (s *implicitTxnStore) Transform(
 	ctx context.Context,
 	source enumerable.Enumerable[Document],

--- a/host-go/store/txn_store.go
+++ b/host-go/store/txn_store.go
@@ -110,13 +110,21 @@ func (s *explicitTxnStore) List(ctx context.Context) (map[string]model.Lens, err
 }
 
 func (s *implicitTxnStore) Delete(ctx context.Context, id string) error {
-	// red stub - intentionally a no-op until the green commit.
-	return nil
+	txn, err := s.newTxn(false)
+	if err != nil {
+		return err
+	}
+	defer txn.Discard()
+
+	if err := delete_(ctx, id, txn); err != nil {
+		return err
+	}
+
+	return txn.Commit()
 }
 
 func (s *explicitTxnStore) Delete(ctx context.Context, id string) error {
-	// red stub - intentionally a no-op until the green commit.
-	return nil
+	return delete_(ctx, id, s.txn)
 }
 
 func (s *implicitTxnStore) Transform(

--- a/tests/action/delete.go
+++ b/tests/action/delete.go
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package action
+
+import (
+	"github.com/stretchr/testify/require"
+)
+
+type Delete struct {
+	Nodeful
+
+	LensID string
+}
+
+var _ Action = (*Delete)(nil)
+var _ Stateful = (*Delete)(nil)
+
+func (a *Delete) Execute() {
+	lensID := replace(a.s, a.LensID)
+
+	for _, n := range a.Nodes() {
+		err := n.Store.Delete(a.s.Ctx, lensID)
+		require.NoError(a.s.T, err)
+	}
+}

--- a/tests/integration/node/delete_test.go
+++ b/tests/integration/node/delete_test.go
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package node
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/lens/host-go/config/model"
+	"github.com/sourcenetwork/lens/tests/action"
+	"github.com/sourcenetwork/lens/tests/integration"
+	"github.com/sourcenetwork/lens/tests/modules"
+)
+
+func TestDelete(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.Add{
+				Config: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: modules.WasmPath1,
+						},
+					},
+				},
+			},
+			&action.List{
+				Expected: map[string]model.Lens{
+					"{{.LensIDs0}}": {
+						Lenses: []model.LensModule{
+							{
+								Path: "{{.WasmBytes0}}",
+							},
+						},
+					},
+				},
+			},
+			&action.Delete{
+				LensID: "{{.LensIDs0}}",
+			},
+			&action.List{
+				Expected: map[string]model.Lens{},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/tests/integration/node/delete_test.go
+++ b/tests/integration/node/delete_test.go
@@ -94,6 +94,75 @@ func TestDeleteAlreadyRemovedIsIdempotent(t *testing.T) {
 	test.Execute(t)
 }
 
+// TestDelete_TxnDiscard asserts that a Delete staged in a transaction does not take
+// effect if the transaction is discarded - the tombstone is transaction-scoped and
+// never reaches the shared index or repository pools.
+func TestDelete_TxnDiscard(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.Add{
+				Config: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: modules.WasmPath1,
+						},
+					},
+				},
+			},
+			&action.TxnCreate{},
+			&action.TxnAction[*action.Delete]{
+				Action: &action.Delete{
+					LensID: "{{.LensIDs0}}",
+				},
+			},
+			&action.TxnDiscard{},
+			&action.List{
+				Expected: map[string]model.Lens{
+					"{{.LensIDs0}}": {
+						Lenses: []model.LensModule{
+							{
+								Path: "{{.WasmBytes0}}",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+// TestDelete_TxnCommit asserts that a Delete staged in a transaction takes effect once
+// the transaction is committed.
+func TestDelete_TxnCommit(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.Add{
+				Config: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: modules.WasmPath1,
+						},
+					},
+				},
+			},
+			&action.TxnCreate{},
+			&action.TxnAction[*action.Delete]{
+				Action: &action.Delete{
+					LensID: "{{.LensIDs0}}",
+				},
+			},
+			&action.TxnCommit{},
+			&action.List{
+				Expected: map[string]model.Lens{},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
 // TestDeleteOneOfMany asserts that deleting one lens leaves the others intact.
 func TestDeleteOneOfMany(t *testing.T) {
 	test := &integration.Test{

--- a/tests/integration/node/delete_test.go
+++ b/tests/integration/node/delete_test.go
@@ -47,3 +47,91 @@ func TestDelete(t *testing.T) {
 
 	test.Execute(t)
 }
+
+// TestDeleteUnknownIsIdempotent asserts that deleting a syntactically valid but
+// unknown lens id returns no error and leaves the store empty.
+func TestDeleteUnknownIsIdempotent(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.Delete{
+				LensID: "bafyreihrdqmhlej6xidpkbwe6ltn2cw34oqvdji4sdh7xbrjciggxzk3ue",
+			},
+			&action.List{
+				Expected: map[string]model.Lens{},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+// TestDeleteAlreadyRemovedIsIdempotent asserts that deleting the same lens twice
+// does not error on the second, already-removed, call.
+func TestDeleteAlreadyRemovedIsIdempotent(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.Add{
+				Config: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: modules.WasmPath1,
+						},
+					},
+				},
+			},
+			&action.Delete{
+				LensID: "{{.LensIDs0}}",
+			},
+			&action.Delete{
+				LensID: "{{.LensIDs0}}",
+			},
+			&action.List{
+				Expected: map[string]model.Lens{},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+// TestDeleteOneOfMany asserts that deleting one lens leaves the others intact.
+func TestDeleteOneOfMany(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.Add{
+				Config: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: modules.WasmPath1,
+						},
+					},
+				},
+			},
+			&action.Add{
+				Config: model.Lens{
+					Lenses: []model.LensModule{
+						{
+							Path: modules.WasmPath2,
+						},
+					},
+				},
+			},
+			&action.Delete{
+				LensID: "{{.LensIDs0}}",
+			},
+			&action.List{
+				Expected: map[string]model.Lens{
+					"{{.LensIDs1}}": {
+						Lenses: []model.LensModule{
+							{
+								Path: "{{.WasmBytes1}}",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #118 

## Description
Implements `Delete` for lenses, completing CRUD surface alongside `Add`/`List`/`Transform`. `Delete` is idempotent: no error is returned for an unknown or already-removed id. It is implemented for both implicit and explicit transaction stores/repositories.

Deletion happens across 2 layers:
- **Store (`store.go` / `txn_store.go`)** — `Delete` removes the index entry that drives `List`, keyed by `configCID.Bytes()` (the same key written by `add` and the p2p `syncLens`). The content-addressed config and module blocks are intentionally left in the blockstore, since they may be shared between lens configs; a lens disappears from `List` once its index entry is gone. It then delegates to the repository to drop the cached instances.
 - **Repository (`repository.go` / `txn_repository.go`)** — `Delete` tombstones the id within the transaction context. Tombstoned ids are hidden from reads before commit and removed from the shared forward/reversed pools on commit. A re-`Add` within the same transaction clears the tombstone, preserving the invariant that an id is never both staged and tombstoned at commit time. Pools have no explicit teardown (GC-based), so a pipe borrowed mid-flight stays alive via Go reference semantics and dropping the map entry is safe.
 
 
 ### Limitations
 - The config/module blocks are not garbage-collected, so deleting a lens reclaims index space but not blockstore space. This is deliberate to support block sharing.

## Tasks

- [x] I made sure the code is well commented, particularly hard-to-understand areas.
- [x] I made sure the repository-held documentation is changed accordingly.
- [x] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/validate-conventional-style.sh](tools/configs/validate-conventional-style.sh).
- [x] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...

## How has this been tested?

 Added integration tests under `tests/integration/node/delete_test.go` plus a `Delete` action in `tests/action/delete.go`, covering:
 - basic lens removal.
 - idempotency (deleting an unknown / already-removed id is a no-op).
 - selective removal (deleting one lens leaves others intact).
 - transaction-scoped tombstone semantics (a tombstone is hidden from reads pre-commit and only applied to the shared pools on commit).
 
Specify the platform(s) on which this was tested:
- MacOS
